### PR TITLE
feat: auto-publish blog drafts on PR merge

### DIFF
--- a/.github/workflows/generate-blog-post.yml
+++ b/.github/workflows/generate-blog-post.yml
@@ -92,9 +92,11 @@ jobs:
 
           ### To publish:
           1. Review and edit the draft in `${{ steps.check.outputs.draft_file }}`
-          2. Move the file from `drafts/` to `posts/`
-          3. Add appropriate tags in the frontmatter
-          4. Merge this PR
+          2. Add appropriate tags in the frontmatter
+          3. Merge this PR
+
+          > **Note:** When this PR is merged, the draft will automatically be moved
+          > from `drafts/` to `posts/` and deployed to the site.
 
           *Generated on ${{ steps.check.outputs.title }} via GitHub Actions*
           EOF

--- a/.github/workflows/publish-blog-post.yml
+++ b/.github/workflows/publish-blog-post.yml
@@ -1,0 +1,43 @@
+name: Publish Blog Post
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'blog-draft')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Move drafts to posts
+        id: move
+        run: |
+          DRAFTS_DIR="blog-src/src/content/drafts"
+          POSTS_DIR="blog-src/src/content/posts"
+          MOVED=false
+
+          for file in "$DRAFTS_DIR"/*.md; do
+            [ -f "$file" ] || continue
+            FILENAME=$(basename "$file")
+            echo "Moving $FILENAME from drafts/ to posts/"
+            mv "$file" "$POSTS_DIR/$FILENAME"
+            MOVED=true
+          done
+
+          echo "moved=$MOVED" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push
+        if: steps.move.outputs.moved == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add blog-src/src/content/drafts/ blog-src/src/content/posts/
+          git commit -m "publish: move blog draft(s) to posts for deployment"
+          git push


### PR DESCRIPTION
Add publish-blog-post.yml workflow that triggers when a PR with the
blog-draft label is merged to master. It moves all drafts from
drafts/ to posts/ and commits, which triggers the existing deploy
pipeline. Also updates the generate workflow PR description to
reflect the new automated flow.

https://claude.ai/code/session_016X1E95TLeXZ8qRNKMDt9Ej