### PR TITLE
draft: Back to Full Sail: Speaking at Hall of Fame Week 2026

### DIFF
--- a/blog-src/src/content.config.ts
+++ b/blog-src/src/content.config.ts
@@ -7,7 +7,7 @@ const posts = defineCollection({
   schema: z.object({
     title: z.string(),
     date: z.date(),
-    category: z.enum(["project-update", "thought-leadership", "dev-session"]),
+    category: z.enum(["project-update", "thought-leadership", "dev-session", "career"]),
     tags: z.array(z.string()),
     excerpt: z.string(),
   }),

--- a/blog-src/src/content/drafts/2026-03-22-speaking-at-full-sail-hof-2026.md
+++ b/blog-src/src/content/drafts/2026-03-22-speaking-at-full-sail-hof-2026.md
@@ -28,8 +28,6 @@ Security is a massive topic, and I didn't expect anyone to absorb all of it in o
 
 The talks were just part of it. I spent time doing one-on-one mentoring sessions, participated in panel discussions, and had plenty of informal conversations with students during meet-and-greets. Those unstructured moments are often where the most meaningful exchanges happen — a student asking what the first year in the industry is really like, or whether they should specialize early or stay broad.
 
-I wasn't there alone, either. My colleagues from Proforma joined me: Brian Carothers, our CIO, and Mike Miller, a Senior Software Engineer who's also a Full Sail alumnus. Having multiple perspectives from the same company gave students a fuller picture of what a technology career can look like at different levels. Proforma also put out a [press release](https://proforma.com/news-158-proforma-supports-the-next-generation-of-tech-professionals-at-full-sail-universitys-hall-of-fame-week.html) about our involvement.
-
 ## Why It Matters
 
 Full Sail is where I got my start. Giving back to that community isn't something I do out of obligation — it's something I genuinely look forward to. The students there are hungry to learn, and they ask sharp questions. Being in that environment reminds me of the energy I had when I was starting out, and honestly, it pushes me to stay sharp too.

--- a/blog-src/src/content/drafts/2026-03-22-speaking-at-full-sail-hof-2026.md
+++ b/blog-src/src/content/drafts/2026-03-22-speaking-at-full-sail-hof-2026.md
@@ -1,0 +1,37 @@
+---
+title: "Back to Full Sail: Speaking at Hall of Fame Week 2026"
+date: 2026-03-22
+category: "career"
+tags: ["full-sail", "speaking", "security", "web-development", "mentoring"]
+excerpt: "Returning to my alma mater as a Hall of Fame inductee to give two presentations and mentor the next generation of tech professionals."
+---
+
+There's something surreal about walking the halls of a school you graduated from — except now you're the one standing at the front of the room. This March, I had the privilege of returning to Full Sail University for Hall of Fame Week 2026, this time as an inductee and speaker.
+
+## Two Talks, Two Worlds
+
+I gave two presentations during the week, and I intentionally chose topics on opposite ends of the spectrum.
+
+### Build & Deploy Your First Website
+
+The first was a hands-on workshop focused on getting students from zero to a live website. We walked through HTML, CSS, and JavaScript fundamentals, customized a professional portfolio template, and deployed it to Netlify — both via drag-and-drop and through GitHub integration for continuous deployment. The goal wasn't to make anyone a senior developer in an hour. It was to show them that the barrier to getting something live on the internet is remarkably low, and that having a portfolio site is one of the most practical things you can do early in your career.
+
+I put together a Reveal.js presentation and a ready-to-use portfolio template so students could follow along and walk away with something tangible. Both are [available on GitHub](https://github.com/mlaplante/deployfirstsitetonetlifyHOF2026) if you want to check them out.
+
+### Security Essentials
+
+The second talk was a deep dive into cybersecurity fundamentals — 85+ slides across 17 sections. We covered the full landscape: phishing and social engineering, malware and ransomware, password security and 2FA, data privacy, incident response, network and mobile security, cloud security, and emerging threats like AI-powered attacks and deepfakes. I also touched on zero trust architecture, secure software development practices including DevSecOps and the OWASP Top 10, and the compliance frameworks (GDPR, HIPAA, PCI DSS) that shape how we operate in the real world.
+
+Security is a massive topic, and I didn't expect anyone to absorb all of it in one sitting. The point was to expose students to the breadth of the field and give them a mental map of where everything fits. That presentation is also [on GitHub](https://github.com/mlaplante/General-Security-knowledge-HOF-2026).
+
+## More Than Presentations
+
+The talks were just part of it. I spent time doing one-on-one mentoring sessions, participated in panel discussions, and had plenty of informal conversations with students during meet-and-greets. Those unstructured moments are often where the most meaningful exchanges happen — a student asking what the first year in the industry is really like, or whether they should specialize early or stay broad.
+
+I wasn't there alone, either. My colleagues from Proforma joined me: Brian Carothers, our CIO, and Mike Miller, a Senior Software Engineer who's also a Full Sail alumnus. Having multiple perspectives from the same company gave students a fuller picture of what a technology career can look like at different levels. Proforma also put out a [press release](https://proforma.com/news-158-proforma-supports-the-next-generation-of-tech-professionals-at-full-sail-universitys-hall-of-fame-week.html) about our involvement.
+
+## Why It Matters
+
+Full Sail is where I got my start. Giving back to that community isn't something I do out of obligation — it's something I genuinely look forward to. The students there are hungry to learn, and they ask sharp questions. Being in that environment reminds me of the energy I had when I was starting out, and honestly, it pushes me to stay sharp too.
+
+If you're in a position to mentor or speak at your alma mater, I'd encourage you to do it. You don't need a polished keynote. You just need to show up, be honest about your experience, and be willing to answer the questions nobody else will.


### PR DESCRIPTION
## Summary
- Blog post about speaking at Full Sail University's Hall of Fame Week 2026 (March 9-11)
- Covers both presentations: "Build & Deploy Your First Website" and "Security Essentials"
- Includes links to GitHub repos for both talks and the Proforma press release

## Test plan
- [ ] Review draft content for accuracy
- [ ] Verify links to repos and press release work
- [ ] Merge to trigger publish workflow