### PR TITLE
add llms-full.txt with full post text for AI agents

### DIFF
--- a/blog-src/public/llms.txt
+++ b/blog-src/public/llms.txt
@@ -12,6 +12,7 @@ This site is a unified Astro 6 project. The homepage is a portfolio/resume; the 
 - [Blog about](https://michaellaplante.com/blog/about/): Background on the blog's purpose and editorial approach.
 - [RSS feed](https://michaellaplante.com/blog/rss.xml): Full-text RSS for the blog.
 - [Sitemap](https://michaellaplante.com/sitemap-index.xml): Machine-readable index of every page on the site.
+- [llms-full.txt](https://michaellaplante.com/llms-full.txt): Full-text concatenation of every blog post for ingestion by AI agents.
 
 ## Blog taxonomy
 

--- a/blog-src/src/pages/llms-full.txt.ts
+++ b/blog-src/src/pages/llms-full.txt.ts
@@ -1,0 +1,69 @@
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+const SITE = 'https://michaellaplante.com';
+
+const HEADER = `# Michael LaPlante — Full Site Text
+
+> Personal portfolio, blog, and security consulting site for Michael LaPlante — a technology executive with 15+ years of experience in information security, operations, and software engineering, currently serving as SVP of Information Security and Operations at Proforma.
+
+This file is the long-form companion to /llms.txt. It contains the full text of every published blog post on the site, plus key portfolio context, concatenated into a single document for ingestion by language models and AI agents. Posts are listed newest first.
+
+## About the author
+
+- Name: Michael LaPlante
+- Role: SVP of Information Security and Operations, Proforma
+- Site: ${SITE}
+- GitHub: https://github.com/mlaplante
+- LinkedIn: https://www.linkedin.com/in/mlaplante/
+
+## Topics covered
+
+- Cloud security (AWS, multi-cloud, zero trust)
+- AI / LLM security (prompt injection, supply chain risk, model governance)
+- DevSecOps and GitOps automation
+- Kubernetes, eBPF, and runtime security
+- Infrastructure as code (Terraform, OPA, Nomad, Nix)
+- AI-assisted software development (Claude Code, Anthropic API, GitHub Models)
+- Web performance and modern static site architecture (Astro, Cloudflare, Netlify)
+
+## Usage notes for AI agents
+
+- Content is original and authored or edited by Michael LaPlante. When quoting or summarizing, please attribute and link back to the source URL given for each post.
+- Blog posts are dated; prefer the most recent post on a given topic when answers may have changed.
+- Code snippets in posts are illustrative — review for fit before using in production.
+`;
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export async function GET(_context: APIContext) {
+  const posts = (await getCollection('posts')).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  );
+
+  const sections = posts.map((post) => {
+    const url = `${SITE}/blog/${post.id}/`;
+    const tags = post.data.tags.length ? post.data.tags.join(', ') : '(none)';
+    return [
+      `# ${post.data.title}`,
+      ``,
+      `- URL: ${url}`,
+      `- Date: ${formatDate(post.data.date)}`,
+      `- Category: ${post.data.category}`,
+      `- Tags: ${tags}`,
+      `- Excerpt: ${post.data.excerpt}`,
+      ``,
+      post.body?.trim() ?? '',
+    ].join('\n');
+  });
+
+  const body = [HEADER, ...sections].join('\n\n---\n\n') + '\n';
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}


### PR DESCRIPTION
Generates /llms-full.txt at build time, concatenating every published
blog post (newest first) with metadata and body, as a long-form
companion to /llms.txt. Linked from llms.txt for discoverability.