### PR TITLE
fix(worker): always run worker first so /api/contact POST isn't 405'd

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,7 +8,7 @@
     "directory": "dist",
     "binding": "ASSETS",
     "not_found_handling": "404-page",
-    "run_worker_first": ["/api/*"]
+    "run_worker_first": true
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
## Summary
- Contact form submits POST to `/api/contact` and the response was `405 Method Not Allowed`
- Root cause: Cloudflare's static-assets layer was intercepting the POST and returning 405 *before* the Worker ran. The array form `run_worker_first: ["/api/*"]` has known reliability gaps (notably when combined with `not_found_handling: "404-page"`) — the same failure mode your 2026-04-16 blog post called out
- Switched `run_worker_first` to `true` so the Worker authoritatively handles every request. Static paths still serve fast — the worker delegates them via `env.ASSETS.fetch(request)` (worker/index.ts:24) and `not_found_handling` still applies through that delegation

## Test plan
- [ ] After deploy, submit the contact form on michaellaplante.com and verify it redirects to `/thank-you/`
- [ ] Confirm a static page (e.g. `/blog/`) still serves and the 404 page still renders for unknown paths
- [ ] Spot-check Worker logs for the submission to confirm the handler ran

https://claude.ai/code/session_01G2EbgT2Xp5QWiZVcAJvsdo

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2EbgT2Xp5QWiZVcAJvsdo)_