### PR TITLE
fix(contact-error): show upstream status/error on-page

### DIFF
--- a/blog-src/src/pages/contact-error.astro
+++ b/blog-src/src/pages/contact-error.astro
@@ -41,8 +41,28 @@ import SiteLayout from '../layouts/SiteLayout.astro';
       <h1>Something went wrong</h1>
       <p>I couldn't send your message right now. Please try again in a few minutes &mdash; or reach out on <a href="https://www.linkedin.com/in/mlaplante/" rel="noopener noreferrer">LinkedIn</a>.</p>
       <a href="/#contact" class="btn btn-custom">Back to the form</a>
+      <details id="diag" hidden class="diag">
+        <summary>Diagnostic info</summary>
+        <dl>
+          <dt>Upstream status</dt><dd id="diag-status">—</dd>
+          <dt>Request ID</dt><dd id="diag-rid">—</dd>
+          <dt>Error</dt><dd id="diag-err">—</dd>
+        </dl>
+      </details>
     </div>
   </div>
+  <script is:inline>
+    (() => {
+      const q = new URLSearchParams(location.search);
+      const s = q.get('s'), rid = q.get('rid'), e = q.get('e');
+      if (!s && !rid && !e) return;
+      const d = document.getElementById('diag');
+      if (s) document.getElementById('diag-status').textContent = s;
+      if (rid) document.getElementById('diag-rid').textContent = rid;
+      if (e) document.getElementById('diag-err').textContent = e;
+      d.hidden = false;
+    })();
+  </script>
   <script is:inline defer src="/js/script.js"></script>
 </SiteLayout>
 
@@ -74,6 +94,35 @@ import SiteLayout from '../layouts/SiteLayout.astro';
   .contact-error .btn {
     animation: fadeSlideUp 0.6s ease 1.8s both;
   }
+  .diag {
+    margin: 28px auto 0;
+    max-width: 460px;
+    text-align: left;
+    font-size: 0.85rem;
+    color: #555;
+    animation: fadeSlideUp 0.6s ease 2.1s both;
+  }
+  .diag summary {
+    cursor: pointer;
+    color: #888;
+    font-weight: 500;
+  }
+  .diag dl {
+    margin: 12px 0 0;
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 4px 12px;
+  }
+  .diag dt {
+    font-weight: 600;
+  }
+  .diag dd {
+    margin: 0;
+    word-break: break-word;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  :global(body.dark-mode) .diag { color: #b0b0b0; }
+  :global(body.dark-mode) .diag summary { color: #888; }
   :global(body.dark-mode) .contact-error p {
     color: #b0b0b0;
   }

--- a/worker/api/contact.ts
+++ b/worker/api/contact.ts
@@ -136,17 +136,18 @@ export async function handleContact(request: Request, env: Env, ctx: ExecutionCo
     const errBody = await mailRes.text();
     const requestId = mailRes.headers.get('X-Request-Id') ?? '';
     console.error('ForwardEmail failed', mailRes.status, 'request-id=', requestId, 'body-len=', mailBody.length, 'err=', errBody);
-    // Submission is still recorded in D1 as a backstop. Redirect to a styled
-    // error page, and surface the upstream status + body on the 303 response
-    // headers so the operator can diagnose without needing wrangler logs —
-    // visible in browser DevTools → Network on the POST to /api/contact.
+    // Submission is still recorded in D1 as a backstop. Surface the upstream
+    // status + truncated body on the redirect URL so the contact-error page
+    // can display them without the operator needing DevTools/wrangler tail.
+    const params = new URLSearchParams({
+      s: String(mailRes.status),
+      e: errBody.replace(/[\r\n]+/g, ' ').slice(0, 300),
+    });
+    if (requestId) params.set('rid', requestId);
     return new Response(null, {
       status: 303,
       headers: {
-        Location: url.origin + CONTACT_ERROR,
-        'X-Mail-Status': String(mailRes.status),
-        'X-Mail-Error': errBody.replace(/[\r\n]+/g, ' ').slice(0, 500),
-        'X-Mail-Request-Id': requestId,
+        Location: `${url.origin}${CONTACT_ERROR}?${params.toString()}`,
         ...NO_STORE,
       },
     });


### PR DESCRIPTION
## Why

The contact form is hitting `/contact-error/` ("Something went wrong") on submit. The JSON-body fix (#99) didn't resolve it, which rules out request format — the failure is upstream (auth / sender domain / rate limit / outage).

The 303 redirect already attaches `X-Mail-Status` / `X-Mail-Error` / `X-Mail-Request-Id`, but those headers vanish once the browser follows the redirect, so reading them requires DevTools. This PR makes the same info visible on the error page so the failure can be diagnosed from a phone.

## Changes

- `worker/api/contact.ts` — drop the response-header approach; pass the upstream status / truncated error body (300 chars) / request id on the redirect URL as `?s=&e=&rid=`.
- `blog-src/src/pages/contact-error.astro` — add a collapsed **Diagnostic info** `<details>` block that reads the params client-side and renders status / request id / error.

## Test plan

- [ ] Deploy worker + assets (`npm run build && npx wrangler deploy`)
- [ ] Submit contact form
- [ ] On the error page, tap "Diagnostic info" and read the upstream status
- [ ] Use that status to identify the real root cause:
  - `401` → `FE_API_KEY` revoked/wrong
  - `403` / `422` → `CONTACT_FROM` sender domain not authorized (DKIM/SPF/MX)
  - `429` → upstream rate limit
  - `5xx` → ForwardEmail outage

https://claude.ai/code/session_01TUETNJT7GQ3VaVRgNVHyxq