### PR TITLE
revert(contact): drop on-page diagnostic surfacing

### DIFF
--- a/blog-src/src/pages/contact-error.astro
+++ b/blog-src/src/pages/contact-error.astro
@@ -41,28 +41,8 @@ import SiteLayout from '../layouts/SiteLayout.astro';
       <h1>Something went wrong</h1>
       <p>I couldn't send your message right now. Please try again in a few minutes &mdash; or reach out on <a href="https://www.linkedin.com/in/mlaplante/" rel="noopener noreferrer">LinkedIn</a>.</p>
       <a href="/#contact" class="btn btn-custom">Back to the form</a>
-      <details id="diag" hidden class="diag">
-        <summary>Diagnostic info</summary>
-        <dl>
-          <dt>Upstream status</dt><dd id="diag-status">—</dd>
-          <dt>Request ID</dt><dd id="diag-rid">—</dd>
-          <dt>Error</dt><dd id="diag-err">—</dd>
-        </dl>
-      </details>
     </div>
   </div>
-  <script is:inline>
-    (() => {
-      const q = new URLSearchParams(location.search);
-      const s = q.get('s'), rid = q.get('rid'), e = q.get('e');
-      if (!s && !rid && !e) return;
-      const d = document.getElementById('diag');
-      if (s) document.getElementById('diag-status').textContent = s;
-      if (rid) document.getElementById('diag-rid').textContent = rid;
-      if (e) document.getElementById('diag-err').textContent = e;
-      d.hidden = false;
-    })();
-  </script>
   <script is:inline defer src="/js/script.js"></script>
 </SiteLayout>
 
@@ -94,35 +74,6 @@ import SiteLayout from '../layouts/SiteLayout.astro';
   .contact-error .btn {
     animation: fadeSlideUp 0.6s ease 1.8s both;
   }
-  .diag {
-    margin: 28px auto 0;
-    max-width: 460px;
-    text-align: left;
-    font-size: 0.85rem;
-    color: #555;
-    animation: fadeSlideUp 0.6s ease 2.1s both;
-  }
-  .diag summary {
-    cursor: pointer;
-    color: #888;
-    font-weight: 500;
-  }
-  .diag dl {
-    margin: 12px 0 0;
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    gap: 4px 12px;
-  }
-  .diag dt {
-    font-weight: 600;
-  }
-  .diag dd {
-    margin: 0;
-    word-break: break-word;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  }
-  :global(body.dark-mode) .diag { color: #b0b0b0; }
-  :global(body.dark-mode) .diag summary { color: #888; }
   :global(body.dark-mode) .contact-error p {
     color: #b0b0b0;
   }

--- a/worker/api/contact.ts
+++ b/worker/api/contact.ts
@@ -136,20 +136,10 @@ export async function handleContact(request: Request, env: Env, ctx: ExecutionCo
     const errBody = await mailRes.text();
     const requestId = mailRes.headers.get('X-Request-Id') ?? '';
     console.error('ForwardEmail failed', mailRes.status, 'request-id=', requestId, 'body-len=', mailBody.length, 'err=', errBody);
-    // Submission is still recorded in D1 as a backstop. Surface the upstream
-    // status + truncated body on the redirect URL so the contact-error page
-    // can display them without the operator needing DevTools/wrangler tail.
-    const params = new URLSearchParams({
-      s: String(mailRes.status),
-      e: errBody.replace(/[\r\n]+/g, ' ').slice(0, 300),
-    });
-    if (requestId) params.set('rid', requestId);
+    // Submission is still recorded in D1 as a backstop.
     return new Response(null, {
       status: 303,
-      headers: {
-        Location: `${url.origin}${CONTACT_ERROR}?${params.toString()}`,
-        ...NO_STORE,
-      },
+      headers: { Location: url.origin + CONTACT_ERROR, ...NO_STORE },
     });
   }
   console.log('ForwardEmail sent ok', mailRes.status);


### PR DESCRIPTION
## Why

PR #100 added a Diagnostic info block to `/contact-error/` that read URL params (`?s=&rid=&e=`) and showed the upstream ForwardEmail status to the submitter. That was a debugging aid to find the root cause without DevTools.

We found it: the Cloudflare Worker only had `FE_API_KEY` and `TURNSTILE_SECRET` defined — `CONTACT_FROM` and `CONTACT_TO` were never set, so `JSON.stringify` silently dropped them, and ForwardEmail returned `400 "Domain does not exist on your account."` That's an operator-side fix (add the two secrets in the Cloudflare dashboard), not a code fix.

With the cause known, the diagnostic UI is dead weight on a user-facing page. Rolling it back.

## Changes

- `worker/api/contact.ts`: drop the `?s=&rid=&e=` URL-param surfacing on the 303 redirect. Restore the plain `Location: /contact-error/` redirect. `console.error` still logs `status / request-id / err` for future `wrangler tail` debugging.
- `blog-src/src/pages/contact-error.astro`: remove the `<details id="diag">` block, the inline script that reads `location.search`, and the associated `.diag` styles.

## Test plan

- [x] `npm run build` succeeds; `/contact-error/index.html` no longer contains the diagnostic block
- [ ] Deploy worker + assets (`npm run build && npx wrangler deploy`)
- [ ] Confirm `CONTACT_FROM` and `CONTACT_TO` secrets are set in the Cloudflare dashboard
- [ ] Submit contact form, confirm `/thank-you/` renders and email arrives

https://claude.ai/code/session_01TUETNJT7GQ3VaVRgNVHyxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUETNJT7GQ3VaVRgNVHyxq)_