### PR TITLE
Add privacy policy, security.txt, full-archive blog search; fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ A modern, fully Astro-powered personal portfolio and security consulting website
 - **Cloudflare Workers Runtime**: Static assets + a Worker that handles `/api/contact` (D1 storage, Turnstile, ForwardEmail)
 - **Responsive Design**: Works seamlessly across desktop, tablet, and mobile
 - **Blog with Taxonomy**: Category and tag pages, RSS feed, related posts, dark mode, in-page reading progress
+- **Full-Archive Blog Search**: Client-side search over a build-time JSON index (`/blog/search.json`) covering every post, not just the current page
+- **Printable Résumé**: `/resume` renders a print-optimized résumé (browser "Save as PDF") from a single shared data module (`src/data/resume.ts`) that also powers the homepage experience/skills sections — one source of truth, no separate file to maintain
 - **AI-Assisted Drafts**: Anthropic / Gemini / GitHub Models integrations for generating blog post drafts
 - **Automated Publishing**: GitHub Actions workflows to draft, promote, and deploy posts
 - **Performance Optimized**: Self-hosted assets, immutable cache headers for hashed bundles, CSS-only effects
-- **Security Hardened**: CSP, HSTS, X-Frame-Options, and Permissions-Policy headers served via the Cloudflare `_headers` file
+- **Security Hardened**: CSP, HSTS, X-Frame-Options, and Permissions-Policy headers served via the Cloudflare `_headers` file; RFC 9116 `/.well-known/security.txt`; privacy policy at `/privacy`
 - **SEO**: Auto-generated sitemap, canonical URLs, structured data (Person, WebSite, BlogPosting, BreadcrumbList), RSS feed, llms.txt + llms-full.txt
 - **Analytics**: Umami self-hosted analytics + Cloudflare Insights
 

--- a/blog-src/public/.well-known/security.txt
+++ b/blog-src/public/.well-known/security.txt
@@ -1,0 +1,7 @@
+# Security policy for michaellaplante.com (RFC 9116)
+# If you believe you've found a security issue, please reach out.
+
+Contact: https://michaellaplante.com/#contact
+Expires: 2027-06-06T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://michaellaplante.com/.well-known/security.txt

--- a/blog-src/public/css/style.css
+++ b/blog-src/public/css/style.css
@@ -718,6 +718,14 @@ footer .copyright{
 	font-size:16px;
 	color:rgba(0,0,0,.6);
 }
+footer .copyright a{
+	color:inherit;
+	text-decoration:underline;
+	margin-left:8px;
+}
+footer .copyright a:hover{
+	opacity:.7;
+}
 
 
 /*==================================================

--- a/blog-src/public/css/style.css
+++ b/blog-src/public/css/style.css
@@ -1290,6 +1290,32 @@ body.dark-mode .btn-custom:hover {
 	background: transparent;
 }
 
+/* Secondary "ghost" button — pairs with .btn-custom in the hero actions. */
+.btn-ghost {
+	background: transparent;
+	color: #3F51B5;
+	box-shadow: none;
+}
+.btn-ghost:hover {
+	background: #3F51B5;
+	color: #fff;
+}
+body.dark-mode .btn-ghost {
+	color: #fff;
+	border-color: #fff;
+}
+body.dark-mode .btn-ghost:hover {
+	background: #fff;
+	color: #3F51B5;
+	border-color: #fff;
+}
+.intro-actions a {
+	margin-top: 10px;
+}
+.intro-actions a + a {
+	margin-left: 14px;
+}
+
 /*==================================================
 	Responsive Adjustments
 ==================================================*/

--- a/blog-src/src/data/resume.ts
+++ b/blog-src/src/data/resume.ts
@@ -1,0 +1,148 @@
+// Single source of truth for résumé-style content shared by the homepage
+// (index.astro) and the printable résumé page (resume.astro). Update a job,
+// skill, or stat here once and both pages stay in sync — there is no separate
+// résumé file to hand-maintain.
+
+export interface ProfileLink {
+  label: string;
+  url: string;
+}
+
+export const profile = {
+  name: 'Michael LaPlante',
+  title: 'SVP of Information Security and Operations',
+  website: 'michaellaplante.com',
+  websiteUrl: 'https://michaellaplante.com',
+  links: [
+    { label: 'LinkedIn', url: 'https://www.linkedin.com/in/mlaplante/' },
+    { label: 'Facebook', url: 'https://www.facebook.com/Laplante.Michael' },
+    { label: 'Twitter', url: 'https://twitter.com/laplantewebdev' },
+    { label: 'Github', url: 'https://github.com/mlaplante' },
+  ] satisfies ProfileLink[],
+};
+
+// Each paragraph of the "About Me" summary. The first renders larger on the
+// homepage; the résumé uses them as the professional summary.
+export const summary = [
+  "I'm an accomplished technology executive with comprehensive expertise in cybersecurity strategy, enterprise operations, and innovative software engineering.",
+  "With over 15 years of distinguished professional experience, I spearhead mission-critical technology initiatives as SVP of Information Security and Operations, delivering measurable impact across complex enterprise environments. My career trajectory showcases proven success in software engineering excellence, advanced security architecture, strategic team leadership, and operational transformation.",
+  "I architect and implement secure, scalable enterprise-grade technology solutions while cultivating high-performing teams that consistently exceed objectives and drive meaningful organizational change. My technical expertise spans multiple programming languages, and I've delivered solutions serving hundreds of satisfied clients while sharing insights through numerous speaking engagements worldwide.",
+];
+
+export interface Stat {
+  value: string;
+  label: string;
+}
+
+export const stats: Stat[] = [
+  { value: '$800M', label: 'Company secured' },
+  { value: '15+', label: 'Years in enterprise security' },
+  { value: '70+', label: 'Speaking engagements' },
+  { value: '500+', label: 'Clients served' },
+];
+
+export interface Skill {
+  name: string;
+  description: string;
+}
+
+export const skills: Skill[] = [
+  { name: 'Cloud Security', description: 'AWS, Azure, GCP architecture hardening and multi-cloud governance' },
+  { name: 'Zero Trust Architecture', description: 'Identity-first security models, micro-segmentation, and continuous verification' },
+  { name: 'DevSecOps', description: 'Security automation in CI/CD pipelines, SAST/DAST, and supply chain security' },
+  { name: 'Threat Modeling', description: 'Risk identification, attack surface analysis, and mitigation planning' },
+  { name: 'AI & LLM Security', description: 'Securing generative AI workflows, prompt injection defense, and data protection' },
+  { name: 'Compliance Frameworks', description: 'SOC 2, ISO 27001, HIPAA, PCI-DSS, and NIST implementation' },
+  { name: 'Incident Response', description: 'IR planning, tabletop exercises, and post-incident analysis' },
+  { name: 'Engineering Leadership', description: 'Scaling teams, building security culture, and technical strategy' },
+  { name: 'Full-Stack Development', description: 'TypeScript, React, Angular, Node.js, and modern web architecture' },
+];
+
+export interface ExperienceEntry {
+  company: string;
+  role: string;
+  date: string;
+  current?: boolean;
+  description: string;
+}
+
+export const experience: ExperienceEntry[] = [
+  {
+    company: 'Proforma',
+    role: 'SVP of Information Security and Operations',
+    date: 'January 2026 - Present',
+    current: true,
+    description:
+      'Leading information security strategy and operational excellence across the organization. Key functions include: establishing and maintaining comprehensive security frameworks, driving compliance with industry standards and regulations, overseeing infrastructure security and risk management, leading cross-functional technology teams, implementing security best practices and policies, and fostering a culture of security awareness throughout the organization. Responsible for strategic planning, vendor management, incident response, and ensuring business continuity while aligning security initiatives with organizational goals.',
+  },
+  {
+    company: 'Proforma',
+    role: 'Vice President of Technology',
+    date: 'April 2022 - January 2026',
+    description:
+      'Led and managed technology teams while driving security and compliance innovation across the organization. Spearheaded strategic initiatives to enhance infrastructure security, implement robust compliance frameworks, and foster a culture of continuous improvement. Oversaw cross-functional teams to deliver secure, scalable solutions that aligned with business objectives and industry best practices.',
+  },
+  {
+    company: 'Proforma',
+    role: 'Director of Engineering',
+    date: 'November 2021 - April 2022',
+    description:
+      'I was responsible for assisting in the continued development of the companies multi-million dollar business management solution software. In my role I was tasked with leading the development teams in executing greenfield and remediation tasks, monthly trainings with team members, coaching of team leaders and providing 1-1 feedback. I was also responsible for 12 month timelines, customer relationships and support, manager training and growth.',
+  },
+  {
+    company: 'Proforma',
+    role: 'Software Development Manager',
+    date: 'July 2019 - November 2021',
+    description:
+      'I was responsible for assisting in the continued development of the companies multi-million dollar business management solution software. In my role I was tasked with leading the development teams in executing greenfield and remediation tasks, monthly trainings with team members, coaching of team leaders and providing 1-1 feedback.',
+  },
+  {
+    company: 'Proforma',
+    role: 'Principal Engineer',
+    date: 'February 2019 - July 2019',
+    description:
+      'I was responsible for assisting in the continued development of the companies multi-million dollar business management solution software. In my role I was tasked with leading the charge on framework decisions, implementing best practices with technologies like Angular, and teaching the entire software team of these practices.',
+  },
+  {
+    company: 'FireEye',
+    role: 'Senior Web Engineer',
+    date: 'June 2015 - February 2019',
+    description:
+      "I was responsible for creating all Front End Development practices for Fireeye's next generation threat portal, Fireeye Intelligence Portal. This meant I worked closely with the design team and managers and stakeholders to come up with a plan and realize that plan into a web application for the company. In doing this we focused with latest technologies in HTML, Css, and Javascript with a focus on React and Redux.",
+  },
+  {
+    company: 'Mobilozophy LLC',
+    role: 'Front End Developer',
+    date: 'Nov 2015 - Oct 2016',
+    description:
+      'I was responsible for helping to shape the mobile interfaces for many of the companies clients. This would include transitioning designs to phonegap markup and applications, or delivering content management systems to match the matching mobile designs. This was a remote job, where most communication was handled through Skype or other communication mediums.',
+  },
+  {
+    company: 'Reboot Coding LLC',
+    role: 'Lead Front End Development Instructor',
+    date: 'Dec 2014 - Jun 2015',
+    description:
+      'I was responsible for creating the front end development curriculum and teaching the basic core principles of front end development to our students. After the base core principles are instilled I teach the more advanced front end specific related courses in the program, including Angular.js and Advanced JavaScript.',
+  },
+  {
+    company: 'Wolters Kluwer Law & Business',
+    role: 'Lead UI Developer',
+    date: 'Dec 2012 - Nov 2014',
+    description:
+      'I worked on a small team responsible for managing all the user interface and interactions of an online web application. My day to day consists of helping to design a new concept and bring it to conception, using modern technologies like HTML5/CSS3 with a mixin of Knockout.js.',
+  },
+  {
+    company: 'Thuzi',
+    role: 'Web Designer',
+    date: 'June 2011 - Dec 2012',
+    description:
+      'I was responsible for managing the User Interface for the companies many clients. I worked mainly with taking a photoshop mockup and converting it to a usable interface. I also dealt with writing custom markup for facebook applications.',
+  },
+  {
+    company: 'Client Intellect',
+    role: 'Web Designer',
+    date: 'July 2010 - Mar 2011',
+    description:
+      'I was responsible for managing the companies internal systems in addition to making constant updates to their client facing websites. This job mainly focused on creating a design in photoshop and converting it to be usable on the client facing sites.',
+  },
+];

--- a/blog-src/src/data/resume.ts
+++ b/blog-src/src/data/resume.ts
@@ -11,6 +11,7 @@ export interface ProfileLink {
 export const profile = {
   name: 'Michael LaPlante',
   title: 'SVP of Information Security and Operations',
+  email: 'michael@michaellaplante.com',
   website: 'michaellaplante.com',
   websiteUrl: 'https://michaellaplante.com',
   links: [

--- a/blog-src/src/pages/blog/[...page].astro
+++ b/blog-src/src/pages/blog/[...page].astro
@@ -48,7 +48,11 @@ const isFirstPage = page.currentPage === 1;
       </div>
     </div>
 
-    <div class="post-grid">
+    <p class="search-status" id="search-status" hidden></p>
+
+    <div class="post-grid" id="search-results" hidden></div>
+
+    <div class="post-grid" id="page-grid">
       {posts.map((post) => {
         const readTime = getReadTime(post.body);
         return (
@@ -115,6 +119,13 @@ const isFirstPage = page.currentPage === 1;
 
   .search-box {
     margin-bottom: 20px;
+  }
+
+  .search-status {
+    font-family: 'Poppins', sans-serif;
+    font-size: 13px;
+    color: #9ca3af;
+    margin: -8px 0 24px;
   }
 
   #blog-search {
@@ -377,6 +388,7 @@ const isFirstPage = page.currentPage === 1;
     #blog-search::placeholder { color: #64748b; }
     #blog-search:focus { border-color: #1a5276; box-shadow: 0 0 0 3px rgba(26, 82, 118, 0.2); }
     .blog-subtitle { color: #94a3b8; }
+    .search-status { color: #64748b; }
     .filter-btn { border-color: #334155; color: #94a3b8; }
     .filter-btn:hover { border-color: #1a5276; color: #60a5fa; }
     .filter-btn.active { background: #1a5276; border-color: #1a5276; color: #fff; }
@@ -401,31 +413,122 @@ const isFirstPage = page.currentPage === 1;
 </style>
 
 <script>
-  // Category filter
+  interface IndexedPost {
+    title: string;
+    excerpt: string;
+    category: string;
+    tags: string[];
+    url: string;
+    dateShort: string;
+    dateISO: string;
+    readTime: number;
+  }
+
+  const searchInput = document.getElementById('blog-search') as HTMLInputElement | null;
+  const pageGrid = document.getElementById('page-grid');
+  const resultsGrid = document.getElementById('search-results');
+  const status = document.getElementById('search-status');
+  const featuredBanner = document.querySelector('.featured-banner') as HTMLElement | null;
+  const pagination = document.querySelector('.pagination') as HTMLElement | null;
+
+  // The blog is paginated 10 posts at a time, so the rendered cards only cover
+  // the current page. Searching loads a static index of every post and renders
+  // matches across the whole archive; clearing it restores the paged view.
+  let indexPromise: Promise<IndexedPost[]> | null = null;
+  function loadIndex(): Promise<IndexedPost[]> {
+    if (!indexPromise) {
+      indexPromise = fetch('/blog/search.json')
+        .then((res) => (res.ok ? res.json() : []))
+        .catch(() => []);
+    }
+    return indexPromise;
+  }
+
+  function activeCategory(): string {
+    const activeBtn = document.querySelector('.filter-btn.active') as HTMLElement | null;
+    return activeBtn?.getAttribute('data-category') || 'all';
+  }
+
+  function escapeHtml(value: string): string {
+    const div = document.createElement('div');
+    div.textContent = value;
+    return div.innerHTML;
+  }
+
+  function renderResults(posts: IndexedPost[], query: string) {
+    const cat = activeCategory();
+    const matches = posts.filter((post) => {
+      const matchesCat = cat === 'all' || post.category === cat;
+      const haystack = [post.title, post.excerpt, post.category, ...post.tags]
+        .join(' ')
+        .toLowerCase();
+      return matchesCat && (!query || haystack.includes(query));
+    });
+
+    if (resultsGrid) {
+      resultsGrid.innerHTML = matches
+        .map(
+          (post) => `
+            <a href="${post.url}" class="post-card" data-category="${escapeHtml(post.category)}">
+              <div class="post-card-meta">
+                <time datetime="${post.dateISO}">${escapeHtml(post.dateShort)}</time>
+                <span class="dot-sep">&middot;</span>
+                <span>${post.readTime} min read</span>
+              </div>
+              <h2>${escapeHtml(post.title)}</h2>
+              <p>${escapeHtml(post.excerpt)}</p>
+              <span class="category-badge">${escapeHtml(post.category.replace(/-/g, ' '))}</span>
+            </a>`
+        )
+        .join('');
+    }
+
+    if (status) {
+      status.hidden = false;
+      status.textContent = matches.length
+        ? `${matches.length} result${matches.length === 1 ? '' : 's'} across the whole blog`
+        : 'No posts found.';
+    }
+  }
+
+  // Filter just the cards on the current page (used when there's no query, so
+  // category buttons still work on the default paged view).
+  function filterCurrentPage() {
+    const cat = activeCategory();
+    pageGrid?.querySelectorAll('.post-card').forEach((card) => {
+      const el = card as HTMLElement;
+      el.style.display = cat === 'all' || el.getAttribute('data-category') === cat ? '' : 'none';
+    });
+  }
+
+  function showSearchView(show: boolean) {
+    if (pageGrid) pageGrid.hidden = show;
+    if (resultsGrid) resultsGrid.hidden = !show;
+    if (featuredBanner) featuredBanner.hidden = show;
+    if (pagination) pagination.hidden = show;
+    if (status && !show) status.hidden = true;
+  }
+
+  async function update() {
+    const query = searchInput?.value.toLowerCase().trim() || '';
+    if (query) {
+      const posts = await loadIndex();
+      showSearchView(true);
+      renderResults(posts, query);
+    } else {
+      showSearchView(false);
+      filterCurrentPage();
+    }
+  }
+
   document.querySelectorAll('.filter-btn').forEach((btn) => {
     btn.addEventListener('click', () => {
       document.querySelectorAll('.filter-btn').forEach((b) => b.classList.remove('active'));
       btn.classList.add('active');
-      applyFilters();
+      update();
     });
   });
   document.querySelector('.filter-btn')?.classList.add('active');
 
-  // Search filter
-  const searchInput = document.getElementById('blog-search') as HTMLInputElement;
-  searchInput?.addEventListener('input', () => applyFilters());
-
-  function applyFilters() {
-    const activeBtn = document.querySelector('.filter-btn.active') as HTMLElement;
-    const cat = activeBtn?.getAttribute('data-category') || 'all';
-    const query = searchInput?.value.toLowerCase().trim() || '';
-
-    document.querySelectorAll('.post-card').forEach((card) => {
-      const el = card as HTMLElement;
-      const matchesCat = cat === 'all' || el.getAttribute('data-category') === cat;
-      const text = el.textContent?.toLowerCase() || '';
-      const matchesSearch = !query || text.includes(query);
-      el.style.display = matchesCat && matchesSearch ? '' : 'none';
-    });
-  }
+  searchInput?.addEventListener('input', () => update());
 </script>

--- a/blog-src/src/pages/blog/search.json.ts
+++ b/blog-src/src/pages/blog/search.json.ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { getReadTime } from '../../utils/readTime';
+import { formatDateShort } from '../../utils/format';
+
+// Static search index for the blog listing page. The listing only paginates
+// 10 posts at a time, so the in-page filter can't see the rest of the archive
+// — this endpoint exposes every post (title/excerpt/tags/category) so the
+// search box can match across the whole blog client-side. Same-origin fetch,
+// so it stays within the site CSP (connect-src 'self').
+export const GET: APIRoute = async () => {
+  const posts = (await getCollection('posts'))
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+    .map((post) => ({
+      title: post.data.title,
+      excerpt: post.data.excerpt,
+      category: post.data.category,
+      tags: post.data.tags,
+      url: `/blog/${post.id}/`,
+      dateShort: formatDateShort(post.data.date),
+      dateISO: post.data.date.toISOString(),
+      readTime: getReadTime(post.body),
+    }));
+
+  return new Response(JSON.stringify(posts), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+    },
+  });
+};

--- a/blog-src/src/pages/index.astro
+++ b/blog-src/src/pages/index.astro
@@ -434,7 +434,7 @@ const posts = (await getCollection('posts'))
 
         <li data-aos="fade-up">
           <div class="date">
-           Febuary 2019 - July 2019
+           February 2019 - July 2019
           </div>
           <div class="content">
             <h4>Proforma</h4>
@@ -449,7 +449,7 @@ const posts = (await getCollection('posts'))
 
         <li data-aos="fade-up">
           <div class="date">
-            June 2015 - Febuary 2019
+            June 2015 - February 2019
           </div>
           <div class="content">
             <h4>FireEye</h4>
@@ -602,6 +602,7 @@ const posts = (await getCollection('posts'))
     <div class="container">
       <p class="copyright" data-aos="fade-up">
         Copyright &copy; LaPlante Web Development 2006-<span id="copyright-year"></span>.
+        <a href="/privacy/">Privacy</a>
       </p>
     </div>
   </footer>

--- a/blog-src/src/pages/index.astro
+++ b/blog-src/src/pages/index.astro
@@ -3,6 +3,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 import { getCollection } from 'astro:content';
 import { getReadTime } from '../utils/readTime';
 import { formatDateShort } from '../utils/format';
+import { profile, summary, stats, skills, experience } from '../data/resume';
 
 const posts = (await getCollection('posts'))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
@@ -116,6 +117,9 @@ const posts = (await getCollection('posts'))
           <li>
             <a href="/uses/">Uses</a>
           </li>
+          <li>
+            <a href="/resume/">Resume</a>
+          </li>
         </ul>
       </div>
     </div>
@@ -145,6 +149,7 @@ const posts = (await getCollection('posts'))
       <!-- CTA -->
       <div class="intro-actions" data-aos="fade-up">
         <a href="#contact" data-scroll class="btn btn-custom">Schedule a Consultation</a>
+        <a href="/resume/" class="btn btn-custom btn-ghost">View Résumé</a>
       </div>
 
     </div>
@@ -160,34 +165,21 @@ const posts = (await getCollection('posts'))
       <!-- about text -->
       <div class="about-text">
 
-        <p class="large" data-aos="fade-up" data-aos-offset="0">
-          I'm an accomplished technology executive with comprehensive expertise in cybersecurity strategy, enterprise operations, and innovative software engineering.
-        </p>
-
-        <p data-aos="fade-up">
-          With over 15 years of distinguished professional experience, I spearhead mission-critical technology initiatives as SVP of Information Security and Operations, delivering measurable impact across complex enterprise environments. My career trajectory showcases proven success in software engineering excellence, advanced security architecture, strategic team leadership, and operational transformation.
-        </p>
-
-        <p data-aos="fade-up">
-          I architect and implement secure, scalable enterprise-grade technology solutions while cultivating high-performing teams that consistently exceed objectives and drive meaningful organizational change. My technical expertise spans multiple programming languages, and I've delivered solutions serving hundreds of satisfied clients while sharing insights through numerous speaking engagements worldwide.
-        </p>
+        {summary.map((para, i) => (
+          <p class={i === 0 ? 'large' : undefined} data-aos="fade-up" data-aos-offset={i === 0 ? '0' : undefined}>
+            {para}
+          </p>
+        ))}
 
       </div>
 
       <!-- social links -->
       <ul class="social-links" data-aos="fade-up">
-        <li>
-          <a href="https://www.linkedin.com/in/mlaplante/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-        </li>
-        <li>
-          <a href="https://www.facebook.com/Laplante.Michael" target="_blank" rel="noopener noreferrer">Facebook</a>
-        </li>
-        <li>
-          <a href="https://twitter.com/laplantewebdev" target="_blank" rel="noopener noreferrer">Twitter</a>
-        </li>
-        <li>
-          <a href="https://github.com/mlaplante" target="_blank" rel="noopener noreferrer">Github</a>
-        </li>
+        {profile.links.map((link) => (
+          <li>
+            <a href={link.url} target="_blank" rel="noopener noreferrer">{link.label}</a>
+          </li>
+        ))}
       </ul>
 
     </div>
@@ -205,33 +197,14 @@ const posts = (await getCollection('posts'))
 
       <div class="row">
 
-        <div class="col-sm-3 col-6">
-          <div class="funfact" data-aos="fade-up">
-            <strong>$800M</strong>
-            <span>Company secured</span>
+        {stats.map((stat) => (
+          <div class="col-sm-3 col-6">
+            <div class="funfact" data-aos="fade-up">
+              <strong>{stat.value}</strong>
+              <span>{stat.label}</span>
+            </div>
           </div>
-        </div>
-
-        <div class="col-sm-3 col-6">
-          <div class="funfact" data-aos="fade-up">
-            <strong>15+</strong>
-            <span>Years in enterprise security</span>
-          </div>
-        </div>
-
-        <div class="col-sm-3 col-6">
-          <div class="funfact" data-aos="fade-up">
-            <strong>70+</strong>
-            <span>Speaking engagements</span>
-          </div>
-        </div>
-
-        <div class="col-sm-3 col-6">
-          <div class="funfact" data-aos="fade-up">
-            <strong>500+</strong>
-            <span>Clients served</span>
-          </div>
-        </div>
+        ))}
 
       </div>
     </div>
@@ -297,60 +270,14 @@ const posts = (await getCollection('posts'))
       </div>
 
       <div class="row">
-        <div class="col-sm-6 col-md-4" data-aos="fade-up">
-          <div class="service">
-            <h4>Cloud Security</h4>
-            <p>AWS, Azure, GCP architecture hardening and multi-cloud governance</p>
+        {skills.map((skill) => (
+          <div class="col-sm-6 col-md-4" data-aos="fade-up">
+            <div class="service">
+              <h4>{skill.name}</h4>
+              <p>{skill.description}</p>
+            </div>
           </div>
-        </div>
-        <div class="col-sm-6 col-md-4" data-aos="fade-up">
-          <div class="service">
-            <h4>Zero Trust Architecture</h4>
-            <p>Identity-first security models, micro-segmentation, and continuous verification</p>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4" data-aos="fade-up">
-          <div class="service">
-            <h4>DevSecOps</h4>
-            <p>Security automation in CI/CD pipelines, SAST/DAST, and supply chain security</p>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4" data-aos="fade-up">
-          <div class="service">
-            <h4>Threat Modeling</h4>
-            <p>Risk identification, attack surface analysis, and mitigation planning</p>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4" data-aos="fade-up">
-          <div class="service">
-            <h4>AI &amp; LLM Security</h4>
-            <p>Securing generative AI workflows, prompt injection defense, and data protection</p>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4" data-aos="fade-up">
-          <div class="service">
-            <h4>Compliance Frameworks</h4>
-            <p>SOC 2, ISO 27001, HIPAA, PCI-DSS, and NIST implementation</p>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4" data-aos="fade-up">
-          <div class="service">
-            <h4>Incident Response</h4>
-            <p>IR planning, tabletop exercises, and post-incident analysis</p>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4" data-aos="fade-up">
-          <div class="service">
-            <h4>Engineering Leadership</h4>
-            <p>Scaling teams, building security culture, and technical strategy</p>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4" data-aos="fade-up">
-          <div class="service">
-            <h4>Full-Stack Development</h4>
-            <p>TypeScript, React, Angular, Node.js, and modern web architecture</p>
-          </div>
-        </div>
+        ))}
       </div>
 
     </div>
@@ -368,155 +295,16 @@ const posts = (await getCollection('posts'))
 
       <ul class="timeline">
 
-        <li class="current" data-aos="fade-up">
-          <div class="date">
-           January 2026 - Present
-          </div>
-          <div class="content">
-            <h4>Proforma</h4>
-            <span>SVP of Information Security and Operations</span>
-            <p>
-              Leading information security strategy and operational excellence across the organization. Key functions include:
-              establishing and maintaining comprehensive security frameworks, driving compliance with industry standards and regulations,
-              overseeing infrastructure security and risk management, leading cross-functional technology teams, implementing security
-              best practices and policies, and fostering a culture of security awareness throughout the organization. Responsible for
-              strategic planning, vendor management, incident response, and ensuring business continuity while aligning security initiatives
-              with organizational goals.
-             </p>
-          </div>
-        </li>
-
-        <li data-aos="fade-up">
-          <div class="date">
-           April 2022 - January 2026
-          </div>
-          <div class="content">
-            <h4>Proforma</h4>
-            <span>Vice President of Technology</span>
-            <p>
-              Led and managed technology teams while driving security and compliance innovation across the organization. Spearheaded strategic initiatives
-              to enhance infrastructure security, implement robust compliance frameworks, and foster a culture of continuous improvement. Oversaw cross-functional
-              teams to deliver secure, scalable solutions that aligned with business objectives and industry best practices.
-             </p>
-          </div>
-        </li>
-
-        <li data-aos="fade-up">
-          <div class="date">
-           November 2021 - April 2022
-          </div>
-          <div class="content">
-            <h4>Proforma</h4>
-            <span>Director of Engineering</span>
-            <p>
-              I was responsible for assisting in the continued development of the companies multi-million dollar business management solution software.
-              In my role I was tasked with leading the development teams in executing greenfield and remediation tasks, monthly trainings with team members,
-              coaching of team leaders and providing 1-1 feedback. I was also responsible for 12 month timelines, customer relationships and support, manager training
-              and growth.
-             </p>
-          </div>
-        </li>
-
-        <li data-aos="fade-up">
-          <div class="date">
-           July 2019 - November 2021
-          </div>
-          <div class="content">
-            <h4>Proforma</h4>
-            <span>Software Development Manager</span>
-            <p>
-              I was responsible for assisting in the continued development of the companies multi-million dollar business management solution software.
-              In my role I was tasked with leading the development teams in executing greenfield and remediation tasks, monthly trainings with team members,
-              coaching of team leaders and providing 1-1 feedback.
-             </p>
-          </div>
-        </li>
-
-        <li data-aos="fade-up">
-          <div class="date">
-           February 2019 - July 2019
-          </div>
-          <div class="content">
-            <h4>Proforma</h4>
-            <span>Principal Engineer</span>
-            <p>
-              I was responsible for assisting in the continued development of the companies multi-million dollar business management solution software.
-              In my role I was tasked with leading the charge on framework decisions, implementing best practices with technologies like Angular, and teaching
-              the entire software team of these practices.
-             </p>
-          </div>
-        </li>
-
-        <li data-aos="fade-up">
-          <div class="date">
-            June 2015 - February 2019
-          </div>
-          <div class="content">
-            <h4>FireEye</h4>
-            <span>Senior Web Engineer</span>
-            <p>I was responsible for creating all Front End Development practices for Fireeye's next generation threat
-            portal, Fireeye Intelligence Portal. This meant I worked closely with the design team and managers and
-            stakeholders to come up with a plan and realize that plan into a web application for the company. In
-            doing this we focused with latest technologies in HTML, Css, and Javascript with a focus on React and
-            Redux
-             </p>
-          </div>
-        </li>
-
-        <li data-aos="fade-up">
-          <div class="date">
-            Nov 2015 - Oct 2016
-          </div>
-          <div class="content">
-            <h4>Mobilozophy LLC</h4>
-            <span>Front End Developer</span>
-            <p>I was responsible for helping to shape the mobile interfaces for many of the companies clients. This would include transitioning designs to phonegap markup and applications, or delivering content management systems to match the matching mobile designs. This was a remote job, where most communication was handled through Skype or other communication mediums.</p>
-          </div>
-        </li>
-
-        <li data-aos="fade-up">
-          <div class="date">
-            Dec 2014 - Jun 2015
-          </div>
-          <div class="content">
-            <h4>Reboot Coding LLC</h4>
-            <span>Lead Front End Development Instructor</span>
-            <p>I was responsible for creating the front end development curriculum and teaching the basic core principles of front end development to our students. After the base core principles are instilled I teach the more advanced front end specific related courses in the program, including Angular.js and Advanced JavaScript.</p>
-          </div>
-        </li>
-
-        <li data-aos="fade-up">
-          <div class="date">
-            Dec 2012 - Nov 2014
-          </div>
-          <div class="content">
-            <h4>Wolters Kluwer Law &amp; Business</h4>
-            <span>Lead UI Developer</span>
-            <p>I worked on a small team responsible for managing all the user interface and interactions of an online web application. My day to day consists of helping to design a new concept and bring it to conception, using modern technologies like HTML5/CSS3 with a mixin of Knockout.js.</p>
-          </div>
-        </li>
-
-        <li data-aos="fade-up">
-          <div class="date">
-            June 2011 - Dec 2012
-          </div>
-          <div class="content">
-            <h4>Thuzi</h4>
-            <span>Web Designer</span>
-            <p>I was responsible for managing the User Interface for the companies many clients. I worked mainly with taking a photoshop mockup and converting it to a usable interface. I also dealt with writing custom markup for facebook applications.</p>
-          </div>
-        </li>
-
-        <li data-aos="fade-up">
-          <div class="date">
-            July 2010 - Mar 2011
-          </div>
-          <div class="content">
-            <h4>Client Intellect</h4>
-            <span>Web Designer</span>
-            <p>I was responsible for managing the companies internal systems in addition to making constant updates to their client facing websites. This job mainly focused on creating a design in photoshop and converting it to be usable on the client facing sites.</p>
-          </div>
-        </li>
+        {experience.map((job) => (
+          <li class={job.current ? 'current' : undefined} data-aos="fade-up">
+            <div class="date">{job.date}</div>
+            <div class="content">
+              <h4>{job.company}</h4>
+              <span>{job.role}</span>
+              <p>{job.description}</p>
+            </div>
+          </li>
+        ))}
 
       </ul>
     </div>

--- a/blog-src/src/pages/privacy.astro
+++ b/blog-src/src/pages/privacy.astro
@@ -43,6 +43,7 @@ const lastUpdated = 'June 6, 2026';
           <li><a href="/">Home</a></li>
           <li><a href="/blog/">Blog</a></li>
           <li><a href="/uses/">Uses</a></li>
+          <li><a href="/resume/">Resume</a></li>
         </ul>
       </div>
     </div>

--- a/blog-src/src/pages/privacy.astro
+++ b/blog-src/src/pages/privacy.astro
@@ -1,0 +1,252 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+
+const lastUpdated = 'June 6, 2026';
+---
+
+<SiteLayout
+  title="Privacy Policy | Michael LaPlante"
+  description="How michaellaplante.com collects, uses, and protects your data — contact form submissions, newsletter signups, and privacy-respecting analytics."
+>
+  <Fragment slot="head">
+    <meta name="author" content="Michael LaPlante">
+    <link rel="stylesheet" type="text/css" href="/css/fonts.css">
+    <link rel="stylesheet" href="/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="/css/linea.css">
+    <link rel="stylesheet" type="text/css" href="/css/style.css">
+  </Fragment>
+
+  <!-- Skip to Content Link for Accessibility -->
+  <a href="#main-content" class="skip-to-content">Skip to main content</a>
+
+  <!--========================================
+    Menu
+  =========================================-->
+  <nav class="top-nav" aria-label="Main navigation">
+    <div class="container">
+
+      <a href="#" class="menu-btn" aria-label="Toggle menu" aria-expanded="false">
+        <span class="lines">
+          <span class="l1"></span>
+          <span class="l2"></span>
+          <span class="l3"></span>
+        </span>
+      </a>
+
+      <button class="dark-mode-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+        <span class="sun-icon">☀️</span>
+        <span class="moon-icon">🌙</span>
+      </button>
+
+      <div class="menu" role="menu">
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="/blog/">Blog</a></li>
+          <li><a href="/uses/">Uses</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <!--========================================
+    Main Content
+  =========================================-->
+  <main id="main-content">
+
+  <section class="section" id="privacy-header" style="padding-top: 120px;">
+    <div class="container">
+      <div class="section-header" data-aos="fade-up">
+        <h1 style='font-size: 18px; font-weight: 700; font-family: "Roboto Mono", monospace; text-transform: lowercase; letter-spacing: 2px; position: relative; display: inline-block;'>privacy</h1>
+      </div>
+      <p data-aos="fade-up" class="updated">Last updated: {lastUpdated}</p>
+    </div>
+  </section>
+
+  <section class="section" id="privacy-body">
+    <div class="container">
+      <div class="legal" data-aos="fade-up">
+
+        <p>
+          This site (<strong>michaellaplante.com</strong>) is the personal
+          portfolio and blog of Michael LaPlante. I keep data collection to a
+          minimum and don't sell or share your personal information. This page
+          explains exactly what's collected, why, and who processes it.
+        </p>
+
+        <h2>Information I collect</h2>
+        <ul>
+          <li>
+            <strong>Contact form.</strong> When you submit the contact form, I
+            collect the name, email address, and message you provide. A hidden
+            anti-spam field and a Cloudflare Turnstile challenge are used to
+            verify you're not a bot.
+          </li>
+          <li>
+            <strong>Newsletter.</strong> If you subscribe to the newsletter, I
+            collect the email address you submit so I can send new-post
+            notifications. You can unsubscribe at any time via the link in
+            every email.
+          </li>
+          <li>
+            <strong>Analytics.</strong> I use privacy-respecting, aggregate
+            analytics to understand which pages are popular. These do not use
+            tracking cookies and do not build advertising profiles of you.
+          </li>
+          <li>
+            <strong>Server logs.</strong> Like any website, my hosting provider
+            records standard request metadata (IP address, user agent,
+            timestamp) for security and abuse prevention.
+          </li>
+        </ul>
+
+        <h2>How I use it</h2>
+        <ul>
+          <li>To respond to messages you send me through the contact form.</li>
+          <li>To deliver the newsletter you asked for.</li>
+          <li>To protect the site from spam, abuse, and security threats.</li>
+          <li>To understand, in aggregate, how the site is used so I can improve it.</li>
+        </ul>
+        <p>
+          I do <strong>not</strong> sell, rent, or trade your personal
+          information, and I don't use it for third-party advertising.
+        </p>
+
+        <h2>Third-party processors</h2>
+        <p>To run the site I rely on a small set of service providers, each of which processes data on my behalf:</p>
+        <ul>
+          <li><strong>Cloudflare</strong> — hosting, CDN, server-side storage of contact-form submissions, and the Turnstile bot challenge.</li>
+          <li><strong>ForwardEmail</strong> — delivery of contact-form submissions to my inbox.</li>
+          <li><strong>Buttondown</strong> — newsletter list management and email delivery.</li>
+          <li><strong>Umami</strong> — self-hosted, cookieless analytics.</li>
+        </ul>
+        <p>Each provider handles your data under its own privacy policy and only for the purpose described above.</p>
+
+        <h2>Cookies &amp; tracking</h2>
+        <p>
+          This site does not use advertising or cross-site tracking cookies.
+          Analytics are cookieless and aggregate. Your browser may store a local
+          preference (such as light/dark mode) on your device; that data never
+          leaves your browser.
+        </p>
+
+        <h2>Data retention</h2>
+        <p>
+          Contact-form submissions are kept only as long as needed to respond
+          to and follow up on your inquiry. Newsletter subscriptions are kept
+          until you unsubscribe. You can ask me to delete your data at any time
+          (see below).
+        </p>
+
+        <h2>Your rights</h2>
+        <p>
+          Depending on where you live, you may have the right to access,
+          correct, or delete the personal information I hold about you, or to
+          object to its processing. To exercise any of these rights — or to ask
+          a question about this policy — just <a href="/#contact">get in touch</a>.
+        </p>
+
+        <h2>Children</h2>
+        <p>This site is not directed at children under 13, and I don't knowingly collect their personal information.</p>
+
+        <h2>Changes to this policy</h2>
+        <p>
+          I may update this policy from time to time. When I do, I'll revise the
+          "Last updated" date at the top of this page. Material changes will be
+          reflected here.
+        </p>
+
+        <h2>Contact</h2>
+        <p>
+          Questions about privacy or your data? Reach out through the
+          <a href="/#contact">contact form</a>.
+        </p>
+
+      </div>
+    </div>
+  </section>
+
+  </main>
+
+  <!--========================================
+    Footer
+  =========================================-->
+  <footer>
+    <div class="container">
+      <p class="copyright" data-aos="fade-up">
+        Copyright &copy; LaPlante Web Development 2006-<span id="copyright-year"></span>.
+        <a href="/privacy/">Privacy</a>
+      </p>
+    </div>
+  </footer>
+
+  <!--========================================
+    JavaScript Files
+  =========================================-->
+  <script is:inline src="/js/script.js"></script>
+</SiteLayout>
+
+<style>
+  .updated {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 13px;
+    color: #6b7280;
+    letter-spacing: 0.5px;
+  }
+
+  .legal {
+    max-width: 760px;
+  }
+
+  .legal p,
+  .legal li {
+    font-family: 'Poppins', sans-serif;
+    font-size: 16px;
+    line-height: 1.8;
+    color: #374151;
+  }
+
+  .legal p {
+    margin-bottom: 18px;
+  }
+
+  .legal h2 {
+    font-family: 'Poppins', sans-serif;
+    font-size: 20px;
+    font-weight: 700;
+    color: #111827;
+    margin: 36px 0 12px;
+  }
+
+  .legal ul {
+    margin: 0 0 18px;
+    padding-left: 22px;
+  }
+
+  .legal li {
+    margin-bottom: 10px;
+  }
+
+  .legal a {
+    color: #2980b9;
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .legal a:hover {
+    opacity: 0.7;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .updated { color: #94a3b8; }
+    .legal p,
+    .legal li { color: #cbd5e1; }
+    .legal h2 { color: #f1f5f9; }
+    .legal a { color: #60a5fa; }
+  }
+
+  :global(body.dark-mode) .updated { color: #94a3b8; }
+  :global(body.dark-mode) .legal p,
+  :global(body.dark-mode) .legal li { color: #cbd5e1; }
+  :global(body.dark-mode) .legal h2 { color: #f1f5f9; }
+  :global(body.dark-mode) .legal a { color: #60a5fa; }
+</style>

--- a/blog-src/src/pages/resume.astro
+++ b/blog-src/src/pages/resume.astro
@@ -60,13 +60,9 @@ import { profile, summary, stats, skills, experience } from '../data/resume';
         <h1>{profile.name}</h1>
         <p class="resume-title">{profile.title}</p>
         <p class="resume-contact">
+          <a href={`mailto:${profile.email}`}>{profile.email}</a>
+          <span class="resume-contact-sep">&middot;</span>
           <a href={profile.websiteUrl}>{profile.website}</a>
-          {profile.links.map((link) => (
-            <Fragment>
-              <span class="resume-contact-sep">&middot;</span>
-              <a href={link.url} target="_blank" rel="noopener noreferrer">{link.label}</a>
-            </Fragment>
-          ))}
         </p>
       </header>
 

--- a/blog-src/src/pages/resume.astro
+++ b/blog-src/src/pages/resume.astro
@@ -1,0 +1,358 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+import { profile, summary, stats, skills, experience } from '../data/resume';
+---
+
+<SiteLayout
+  title="Résumé | Michael LaPlante"
+  description="Résumé of Michael LaPlante — SVP of Information Security and Operations. 15+ years across information security, engineering leadership, and software development."
+>
+  <Fragment slot="head">
+    <meta name="author" content="Michael LaPlante">
+    <link rel="stylesheet" type="text/css" href="/css/fonts.css">
+    <link rel="stylesheet" href="/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="/css/linea.css">
+    <link rel="stylesheet" type="text/css" href="/css/style.css">
+  </Fragment>
+
+  <!-- Skip to Content Link for Accessibility -->
+  <a href="#main-content" class="skip-to-content">Skip to main content</a>
+
+  <!--========================================
+    Menu
+  =========================================-->
+  <nav class="top-nav" aria-label="Main navigation">
+    <div class="container">
+
+      <a href="#" class="menu-btn" aria-label="Toggle menu" aria-expanded="false">
+        <span class="lines">
+          <span class="l1"></span>
+          <span class="l2"></span>
+          <span class="l3"></span>
+        </span>
+      </a>
+
+      <button class="dark-mode-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+        <span class="sun-icon">☀️</span>
+        <span class="moon-icon">🌙</span>
+      </button>
+
+      <div class="menu" role="menu">
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="/blog/">Blog</a></li>
+          <li><a href="/uses/">Uses</a></li>
+          <li><a href="/resume/">Resume</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <main id="main-content" class="resume-page">
+    <div class="resume-toolbar">
+      <a href="/" class="resume-back">&larr; Back to site</a>
+      <button type="button" id="resume-print" class="resume-print-btn">Download PDF</button>
+    </div>
+
+    <article class="resume-paper">
+
+      <header class="resume-header">
+        <h1>{profile.name}</h1>
+        <p class="resume-title">{profile.title}</p>
+        <p class="resume-contact">
+          <a href={profile.websiteUrl}>{profile.website}</a>
+          {profile.links.map((link) => (
+            <Fragment>
+              <span class="resume-contact-sep">&middot;</span>
+              <a href={link.url} target="_blank" rel="noopener noreferrer">{link.label}</a>
+            </Fragment>
+          ))}
+        </p>
+      </header>
+
+      <section class="resume-section">
+        <h2>Summary</h2>
+        {summary.map((para) => <p class="resume-summary">{para}</p>)}
+      </section>
+
+      <section class="resume-section">
+        <h2>Highlights</h2>
+        <div class="resume-stats">
+          {stats.map((stat) => (
+            <div class="resume-stat">
+              <strong>{stat.value}</strong>
+              <span>{stat.label}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section class="resume-section">
+        <h2>Areas of Expertise</h2>
+        <div class="resume-skills">
+          {skills.map((skill) => (
+            <div class="resume-skill">
+              <h3>{skill.name}</h3>
+              <p>{skill.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section class="resume-section">
+        <h2>Experience</h2>
+        {experience.map((job) => (
+          <div class="resume-job">
+            <div class="resume-job-head">
+              <h3>{job.role} <span class="resume-job-company">&middot; {job.company}</span></h3>
+              <span class="resume-job-date">{job.date}</span>
+            </div>
+            <p>{job.description}</p>
+          </div>
+        ))}
+      </section>
+
+    </article>
+  </main>
+
+  <!--========================================
+    Footer
+  =========================================-->
+  <footer>
+    <div class="container">
+      <p class="copyright" data-aos="fade-up">
+        Copyright &copy; LaPlante Web Development 2006-<span id="copyright-year"></span>.
+        <a href="/privacy/">Privacy</a>
+      </p>
+    </div>
+  </footer>
+
+  <script is:inline src="/js/script.js"></script>
+  <script is:inline>
+    document.getElementById('resume-print')?.addEventListener('click', () => window.print());
+  </script>
+</SiteLayout>
+
+<style>
+  .resume-page {
+    padding: 110px 16px 40px;
+    background: #f1f3f5;
+    min-height: 100vh;
+  }
+
+  .resume-toolbar {
+    max-width: 820px;
+    margin: 0 auto 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .resume-back {
+    font-family: 'Poppins', sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    color: #2980b9;
+    text-decoration: none;
+  }
+  .resume-back:hover { opacity: 0.7; }
+
+  .resume-print-btn {
+    font-family: 'Poppins', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    padding: 10px 22px;
+    border: none;
+    border-radius: 8px;
+    background: #2980b9;
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+  .resume-print-btn:hover { background: #1a6da3; }
+
+  /* The résumé "paper" — kept light in both color schemes so it reads like a
+     printed document and the on-screen view matches the PDF. */
+  .resume-paper {
+    max-width: 820px;
+    margin: 0 auto;
+    background: #fff;
+    color: #1f2937;
+    padding: 56px 60px;
+    border-radius: 10px;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+  }
+
+  .resume-header {
+    border-bottom: 2px solid #1a5276;
+    padding-bottom: 18px;
+    margin-bottom: 26px;
+  }
+
+  .resume-header h1 {
+    font-family: 'Poppins', sans-serif;
+    font-size: 32px;
+    font-weight: 700;
+    color: #111827;
+    margin: 0 0 4px;
+    letter-spacing: -0.5px;
+  }
+
+  .resume-title {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 14px;
+    color: #1a5276;
+    margin: 0 0 12px;
+    letter-spacing: 0.5px;
+  }
+
+  .resume-contact {
+    font-family: 'Poppins', sans-serif;
+    font-size: 13px;
+    margin: 0;
+    color: #6b7280;
+  }
+  .resume-contact a { color: #2980b9; text-decoration: none; }
+  .resume-contact a:hover { opacity: 0.7; }
+  .resume-contact-sep { margin: 0 8px; color: #d1d5db; }
+
+  .resume-section { margin-bottom: 30px; }
+
+  .resume-section > h2 {
+    font-family: 'Poppins', sans-serif;
+    font-size: 14px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: #1a5276;
+    margin: 0 0 14px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .resume-summary {
+    font-family: 'Poppins', sans-serif;
+    font-size: 14px;
+    line-height: 1.7;
+    color: #374151;
+    margin: 0 0 12px;
+  }
+
+  .resume-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+  }
+  .resume-stat {
+    flex: 1 1 140px;
+    text-align: center;
+    background: #f8fafc;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 14px 10px;
+  }
+  .resume-stat strong {
+    display: block;
+    font-family: 'Poppins', sans-serif;
+    font-size: 22px;
+    font-weight: 700;
+    color: #1a5276;
+  }
+  .resume-stat span {
+    font-family: 'Poppins', sans-serif;
+    font-size: 12px;
+    color: #6b7280;
+  }
+
+  .resume-skills {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px 28px;
+  }
+  .resume-skill h3 {
+    font-family: 'Poppins', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    color: #111827;
+    margin: 0 0 2px;
+  }
+  .resume-skill p {
+    font-family: 'Poppins', sans-serif;
+    font-size: 13px;
+    line-height: 1.5;
+    color: #6b7280;
+    margin: 0;
+  }
+
+  .resume-job {
+    margin-bottom: 20px;
+  }
+  .resume-job-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+  }
+  .resume-job-head h3 {
+    font-family: 'Poppins', sans-serif;
+    font-size: 15px;
+    font-weight: 700;
+    color: #111827;
+    margin: 0;
+  }
+  .resume-job-company { font-weight: 500; color: #1a5276; }
+  .resume-job-date {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 12px;
+    color: #6b7280;
+    white-space: nowrap;
+  }
+  .resume-job p {
+    font-family: 'Poppins', sans-serif;
+    font-size: 13px;
+    line-height: 1.6;
+    color: #374151;
+    margin: 4px 0 0;
+  }
+
+  @media (max-width: 600px) {
+    .resume-paper { padding: 32px 22px; }
+    .resume-skills { grid-template-columns: 1fr; }
+    .resume-job-head { flex-direction: column; gap: 2px; }
+  }
+
+  /* Page chrome (background) follows dark mode; the paper stays light. */
+  @media (prefers-color-scheme: dark) {
+    .resume-page { background: #0f172a; }
+  }
+  :global(body.dark-mode) .resume-page { background: #0f172a; }
+
+  /* Print: strip chrome, flatten the paper to the page. */
+  @media print {
+    @page { margin: 0.5in; }
+    .top-nav,
+    .resume-toolbar,
+    .skip-to-content,
+    footer {
+      display: none !important;
+    }
+    .resume-page {
+      padding: 0 !important;
+      background: #fff !important;
+      min-height: 0 !important;
+    }
+    .resume-paper {
+      max-width: none !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      box-shadow: none !important;
+      border-radius: 0 !important;
+    }
+    .resume-section,
+    .resume-job,
+    .resume-skill,
+    .resume-stat { break-inside: avoid; }
+    .resume-contact a,
+    .resume-job-company { color: #1a5276 !important; }
+  }
+</style>

--- a/blog-src/src/pages/uses.astro
+++ b/blog-src/src/pages/uses.astro
@@ -39,6 +39,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
           <li><a href="/">Home</a></li>
           <li><a href="/blog/">Blog</a></li>
           <li><a href="/uses/">Uses</a></li>
+          <li><a href="/resume/">Resume</a></li>
         </ul>
       </div>
     </div>

--- a/blog-src/src/pages/uses.astro
+++ b/blog-src/src/pages/uses.astro
@@ -224,6 +224,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
     <div class="container">
       <p class="copyright" data-aos="fade-up">
         Copyright &copy; LaPlante Web Development 2006-<span id="copyright-year"></span>.
+        <a href="/privacy/">Privacy</a>
       </p>
     </div>
   </footer>


### PR DESCRIPTION
- Add /privacy policy page covering contact form, newsletter, analytics,
  Turnstile, and third-party processors; link it from site footers
- Add RFC 9116 .well-known/security.txt pointing to the contact form
- Replace the per-page blog search (which only saw the current 10 posts)
  with a build-time JSON index over all posts, searched client-side across
  the whole archive; stays same-origin so the strict CSP is unchanged
- Fix "Febuary" -> "February" in the experience timeline