### PR TITLE
Add services page, post author bio + series, JSON feed, certs, nav unification

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ A modern, fully Astro-powered personal portfolio and security consulting website
 - **Unified Astro Build**: Entire site (portfolio + blog) built as a single Astro 6 project
 - **Cloudflare Workers Runtime**: Static assets + a Worker that handles `/api/contact` (D1 storage, Turnstile, ForwardEmail)
 - **Responsive Design**: Works seamlessly across desktop, tablet, and mobile
-- **Blog with Taxonomy**: Category and tag pages, RSS feed, related posts, dark mode, in-page reading progress
+- **Blog with Taxonomy**: Category, tag, and multi-part **series** pages, RSS + JSON feeds, related posts, per-post author bio, desktop + mobile tables of contents, dark mode, in-page reading progress
 - **Full-Archive Blog Search**: Client-side search over a build-time JSON index (`/blog/search.json`) covering every post, not just the current page
-- **Printable Résumé**: `/resume` renders a print-optimized résumé (browser "Save as PDF") from a single shared data module (`src/data/resume.ts`) that also powers the homepage experience/skills sections — one source of truth, no separate file to maintain
+- **Printable Résumé**: `/resume` renders a print-optimized résumé (browser "Save as PDF") from a single shared data module (`src/data/resume.ts`) that also powers the homepage experience/skills/certifications sections — one source of truth, no separate file to maintain
+- **Consulting Services Page**: `/services` lays out the consulting offerings, engagement process, and a `ProfessionalService` structured-data block for the security-consulting side of the business
 - **AI-Assisted Drafts**: Anthropic / Gemini / GitHub Models integrations for generating blog post drafts
 - **Automated Publishing**: GitHub Actions workflows to draft, promote, and deploy posts
 - **Performance Optimized**: Self-hosted assets, immutable cache headers for hashed bundles, CSS-only effects
 - **Security Hardened**: CSP, HSTS, X-Frame-Options, and Permissions-Policy headers served via the Cloudflare `_headers` file; RFC 9116 `/.well-known/security.txt`; privacy policy at `/privacy`
-- **SEO**: Auto-generated sitemap, canonical URLs, structured data (Person, WebSite, BlogPosting, BreadcrumbList), RSS feed, llms.txt + llms-full.txt
+- **SEO**: Auto-generated sitemap, canonical URLs, structured data (Person, WebSite, ProfessionalService, BlogPosting, BreadcrumbList), RSS + JSON feeds, llms.txt + llms-full.txt
 - **Analytics**: Umami self-hosted analytics + Cloudflare Insights
 
 ## Technology Stack

--- a/blog-src/src/components/AuthorBio.astro
+++ b/blog-src/src/components/AuthorBio.astro
@@ -1,0 +1,137 @@
+---
+// Author bio box rendered at the foot of every blog post — turns a good read
+// into "who is this / can I hire them". Pulls from the shared résumé profile.
+import { profile } from '../data/resume';
+---
+
+<aside class="author-bio" aria-label="About the author">
+  <picture>
+    <source srcset="/images/mike-laplante-200.webp" type="image/webp" />
+    <img
+      src="/images/mike-laplante-200.jpg"
+      alt="Michael LaPlante"
+      class="author-bio-photo"
+      width="200"
+      height="200"
+      loading="lazy"
+    />
+  </picture>
+  <div class="author-bio-body">
+    <span class="author-bio-label">Written by</span>
+    <h3 class="author-bio-name">{profile.name}</h3>
+    <p class="author-bio-role">{profile.title}</p>
+    <p class="author-bio-text">
+      Technology executive with 15+ years across information security, engineering
+      leadership, and software development. I write about security, AI, and building
+      resilient systems — and I consult on the same.
+    </p>
+    <div class="author-bio-links">
+      {profile.links.map((link) => (
+        <a href={link.url} target="_blank" rel="noopener noreferrer">{link.label}</a>
+      ))}
+      <a href="/services/">Work with me</a>
+    </div>
+  </div>
+</aside>
+
+<style>
+  .author-bio {
+    display: flex;
+    gap: 24px;
+    align-items: flex-start;
+    margin-top: 48px;
+    padding: 28px 32px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+  }
+
+  .author-bio-photo {
+    width: 88px;
+    height: 88px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin: 0;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  }
+
+  .author-bio-body {
+    min-width: 0;
+  }
+
+  .author-bio-label {
+    font-family: 'Poppins', sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #2980b9;
+  }
+
+  .author-bio-name {
+    font-family: 'Poppins', sans-serif;
+    font-size: 18px;
+    font-weight: 700;
+    color: #111827;
+    margin: 4px 0 2px;
+  }
+
+  .author-bio-role {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 12px;
+    color: #6b7280;
+    margin: 0 0 12px;
+    letter-spacing: 0.3px;
+  }
+
+  .author-bio-text {
+    font-family: 'Poppins', sans-serif;
+    font-size: 14px;
+    line-height: 1.6;
+    color: #374151;
+    margin: 0 0 14px;
+  }
+
+  .author-bio-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .author-bio-links a {
+    font-family: 'Poppins', sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    color: #2980b9;
+    text-decoration: none;
+    transition: opacity 0.2s;
+  }
+
+  .author-bio-links a:hover {
+    opacity: 0.7;
+  }
+
+  @media (max-width: 560px) {
+    .author-bio {
+      flex-direction: column;
+      gap: 16px;
+      padding: 24px;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .author-bio { background: #1e293b; border-color: #334155; }
+    .author-bio-photo { box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3); }
+    .author-bio-label { color: #60a5fa; }
+    .author-bio-name { color: #f1f5f9; }
+    .author-bio-role { color: #94a3b8; }
+    .author-bio-text { color: #cbd5e1; }
+    .author-bio-links a { color: #60a5fa; }
+  }
+  :global(body.dark-mode) .author-bio { background: #1e293b; border-color: #334155; }
+  :global(body.dark-mode) .author-bio-name { color: #f1f5f9; }
+  :global(body.dark-mode) .author-bio-role { color: #94a3b8; }
+  :global(body.dark-mode) .author-bio-text { color: #cbd5e1; }
+  :global(body.dark-mode) .author-bio-links a { color: #60a5fa; }
+  :global(body.dark-mode) .author-bio-label { color: #60a5fa; }
+</style>

--- a/blog-src/src/components/BaseHead.astro
+++ b/blog-src/src/components/BaseHead.astro
@@ -54,8 +54,9 @@ const canonicalUrl = canonical ?? `${SITE_URL}${Astro.url.pathname}`;
 <meta name="theme-color" content="#2980b9" media="(prefers-color-scheme: light)" />
 <meta name="theme-color" content="#1a5276" media="(prefers-color-scheme: dark)" />
 
-<!-- RSS autodiscovery -->
+<!-- RSS / JSON Feed autodiscovery -->
 <link rel="alternate" type="application/rss+xml" title="Michael LaPlante's Blog" href="/blog/rss.xml" />
+<link rel="alternate" type="application/feed+json" title="Michael LaPlante's Blog (JSON Feed)" href="/feed.json" />
 
 <!-- Self-hosted Umami analytics -->
 <link rel="preconnect" href="https://laplantedevanalytics.netlify.app" crossorigin />

--- a/blog-src/src/content.config.ts
+++ b/blog-src/src/content.config.ts
@@ -17,6 +17,11 @@ const posts = defineCollection({
     excerpt: z.string().min(1).max(300),
     // Optional explicit hero image; falls back to DEFAULT_OG_IMAGE.
     image: z.string().optional(),
+    // Optional series grouping. Posts sharing the same `series` string are
+    // linked together (series box on each post + a /blog/series/<slug> index),
+    // ordered by `seriesOrder` (ascending), then date.
+    series: z.string().min(1).optional(),
+    seriesOrder: z.number().optional(),
   }),
 });
 

--- a/blog-src/src/data/resume.ts
+++ b/blog-src/src/data/resume.ts
@@ -59,6 +59,22 @@ export const skills: Skill[] = [
   { name: 'Full-Stack Development', description: 'TypeScript, React, Angular, Node.js, and modern web architecture' },
 ];
 
+export interface Certification {
+  name: string;
+  // Issuing body, e.g. "ISC2", "ISACA", "Amazon Web Services".
+  issuer: string;
+  // Optional year earned and a verification/credential URL.
+  year?: string;
+  url?: string;
+}
+
+// Professional certifications. Intentionally empty until real credentials are
+// supplied — never list a certification that isn't actually held. The homepage
+// and résumé only render the "Certifications" section when this array is
+// non-empty, so leaving it empty publishes nothing. To populate:
+//   { name: 'CISSP', issuer: 'ISC2', year: '2024', url: 'https://...' }
+export const certifications: Certification[] = [];
+
 export interface ExperienceEntry {
   company: string;
   role: string;

--- a/blog-src/src/layouts/BlogLayout.astro
+++ b/blog-src/src/layouts/BlogLayout.astro
@@ -51,8 +51,11 @@ const fullTitle = `${title} | Michael LaPlante`;
         <a href="/">Michael LaPlante</a>
         <div class="nav-links">
           <a href="/">Home</a>
+          <a href="/services/">Services</a>
           <a href={baseUrl}>Blog</a>
           <a href={`${baseUrl}/about/`}>About</a>
+          <a href="/uses/">Uses</a>
+          <a href="/resume/">Résumé</a>
           <a href={`${baseUrl}/rss.xml`} title="RSS Feed">RSS</a>
         </div>
       </div>

--- a/blog-src/src/pages/blog/[slug].astro
+++ b/blog-src/src/pages/blog/[slug].astro
@@ -2,9 +2,11 @@
 import { getCollection, render } from 'astro:content';
 import BlogLayout from '../../layouts/BlogLayout.astro';
 import NewsletterSignup from '../../components/NewsletterSignup.astro';
+import AuthorBio from '../../components/AuthorBio.astro';
 import { SITE_URL } from '../../config';
 import { getReadTime, getWordCount } from '../../utils/readTime';
 import { formatDateLong, formatDateShort } from '../../utils/format';
+import { slugify } from '../../utils/slug';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
@@ -27,6 +29,21 @@ const postUrl = `${siteUrl}/blog/${post.id}/`;
 // src/pages/og/[slug].png.ts.
 const heroImage = post.data.image ?? `${siteUrl}/og/${post.id}.png`;
 const updated = post.data.updated ?? post.data.date;
+
+// Series: sibling posts sharing this post's `series`, ordered by seriesOrder
+// (ascending), then date. Empty unless this post opts into a series.
+const seriesName = post.data.series;
+const seriesPosts = seriesName
+  ? allPosts
+      .filter((p) => p.data.series === seriesName)
+      .sort((a, b) => {
+        const ao = a.data.seriesOrder ?? Number.POSITIVE_INFINITY;
+        const bo = b.data.seriesOrder ?? Number.POSITIVE_INFINITY;
+        if (ao !== bo) return ao - bo;
+        return a.data.date.valueOf() - b.data.date.valueOf();
+      })
+  : [];
+const seriesIndex = seriesPosts.findIndex((p) => p.id === post.id);
 
 // Related posts: same category first, then recent, exclude current
 const relatedPosts = allPosts
@@ -128,8 +145,39 @@ const breadcrumbSchema = JSON.stringify({
             <a href={`/blog/tags/${tag}/`} class="tag-link">{tag}</a>
           ))}
         </div>
+
+        {seriesPosts.length > 1 && (
+          <nav class="series-box" aria-label="Posts in this series">
+            <span class="series-box-label">
+              Part {seriesIndex + 1} of {seriesPosts.length} in the series
+            </span>
+            <a class="series-box-title" href={`/blog/series/${slugify(seriesName!)}/`}>{seriesName}</a>
+            <ol class="series-box-list">
+              {seriesPosts.map((p, i) => (
+                <li class={p.id === post.id ? 'series-current' : undefined}>
+                  {p.id === post.id ? (
+                    <span><span class="series-num">{i + 1}.</span> {p.data.title}</span>
+                  ) : (
+                    <a href={`/blog/${p.id}/`}><span class="series-num">{i + 1}.</span> {p.data.title}</a>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
+        )}
+
+        <!-- Inline table of contents (mobile / narrow viewports where the
+             sidebar TOC is hidden). Populated and toggled by the TOC script. -->
+        <details class="toc-inline">
+          <summary>Table of Contents</summary>
+          <nav class="toc-inline-nav" id="toc-inline-nav" aria-label="Table of contents"></nav>
+        </details>
+
         <Content />
       </article>
+
+      <!-- Author Bio -->
+      <AuthorBio />
 
       <!-- Newsletter CTA -->
       <NewsletterSignup showAlt={true} />
@@ -241,6 +289,110 @@ const breadcrumbSchema = JSON.stringify({
   .toc-nav :global(a.toc-h3) {
     padding-left: 24px;
     font-size: 12px;
+  }
+
+  /* Inline TOC — only shown where the sidebar TOC is hidden (< 960px). */
+  .toc-inline {
+    margin: 0 0 28px;
+    padding: 4px 18px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+  }
+
+  @media (min-width: 960px) {
+    .toc-inline { display: none; }
+  }
+
+  .toc-inline summary {
+    font-family: 'Poppins', sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    color: #111827;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 12px 0;
+    cursor: pointer;
+  }
+
+  .toc-inline-nav {
+    padding: 0 0 12px;
+  }
+
+  .toc-inline-nav :global(a) {
+    display: block;
+    font-family: 'Poppins', sans-serif;
+    font-size: 13px;
+    color: #6b7280;
+    text-decoration: none;
+    padding: 5px 0 5px 12px;
+    border-left: 2px solid #e5e7eb;
+    line-height: 1.5;
+  }
+
+  .toc-inline-nav :global(a.toc-h3) {
+    padding-left: 24px;
+    font-size: 12px;
+  }
+
+  /* Series box */
+  .series-box {
+    margin: 0 0 28px;
+    padding: 18px 22px;
+    background: rgba(41, 128, 185, 0.05);
+    border: 1px solid rgba(41, 128, 185, 0.18);
+    border-radius: 10px;
+  }
+
+  .series-box-label {
+    display: block;
+    font-family: 'Poppins', sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #2980b9;
+  }
+
+  .series-box-title {
+    display: inline-block;
+    font-family: 'Poppins', sans-serif;
+    font-size: 17px;
+    font-weight: 700;
+    color: #111827;
+    text-decoration: none;
+    margin: 4px 0 10px;
+  }
+  .series-box-title:hover { color: #2980b9; }
+
+  .series-box-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    counter-reset: none;
+  }
+
+  .series-box-list li {
+    font-family: 'Poppins', sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 4px 0;
+  }
+
+  .series-box-list .series-num {
+    color: #9ca3af;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .series-box-list a {
+    color: #2980b9;
+    text-decoration: none;
+  }
+  .series-box-list a:hover { text-decoration: underline; }
+
+  .series-box-list .series-current {
+    color: #374151;
+    font-weight: 600;
   }
 
   .blog-meta .dot-sep {
@@ -424,6 +576,16 @@ const breadcrumbSchema = JSON.stringify({
     .toc-nav :global(a) { color: #94a3b8; border-left-color: #334155; }
     .toc-nav :global(a:hover) { color: #60a5fa; }
     .toc-nav :global(a.active) { color: #60a5fa; border-left-color: #60a5fa; }
+    .toc-inline { background: #1e293b; border-color: #334155; }
+    .toc-inline summary { color: #e2e8f0; }
+    .toc-inline-nav :global(a) { color: #94a3b8; border-left-color: #334155; }
+    .series-box { background: rgba(96, 165, 250, 0.08); border-color: rgba(96, 165, 250, 0.2); }
+    .series-box-label { color: #60a5fa; }
+    .series-box-title { color: #f1f5f9; }
+    .series-box-title:hover { color: #60a5fa; }
+    .series-box-list .series-num { color: #64748b; }
+    .series-box-list a { color: #60a5fa; }
+    .series-box-list .series-current { color: #e2e8f0; }
     .blog-meta .dot-sep { color: #475569; }
     .breadcrumbs a { color: #94a3b8; }
     .breadcrumbs a:hover { color: #60a5fa; }
@@ -448,34 +610,50 @@ const breadcrumbSchema = JSON.stringify({
 </style>
 
 <script>
-  // Generate TOC from article headings
+  // Generate TOC from article headings — populates both the desktop sidebar
+  // and the inline (mobile) collapsible TOC from one heading pass.
   function buildTOC() {
     const article = document.querySelector('.article-main article');
     const tocNav = document.getElementById('toc-nav');
-    if (!article || !tocNav) return;
+    const tocInlineNav = document.getElementById('toc-inline-nav');
+    const tocInline = document.querySelector('.toc-inline') as HTMLElement | null;
+    if (!article) return;
 
     const headings = article.querySelectorAll('h2, h3');
     if (headings.length === 0) {
       const sidebar = document.querySelector('.toc-sidebar') as HTMLElement;
       if (sidebar) sidebar.style.display = 'none';
+      if (tocInline) tocInline.style.display = 'none';
       return;
     }
 
+    const makeLink = (heading: Element) => {
+      const link = document.createElement('a');
+      link.href = `#${heading.id}`;
+      link.textContent = heading.textContent || '';
+      if (heading.tagName === 'H3') link.classList.add('toc-h3');
+      return link;
+    };
+
+    const inlineDetails = tocInline as HTMLDetailsElement | null;
     headings.forEach((heading, i) => {
       if (!heading.id) {
         heading.id = `heading-${i}`;
       }
-
-      const link = document.createElement('a');
-      link.href = `#${heading.id}`;
-      link.textContent = heading.textContent || '';
-      if (heading.tagName === 'H3') {
-        link.classList.add('toc-h3');
+      tocNav?.appendChild(makeLink(heading));
+      if (tocInlineNav) {
+        const inlineLink = makeLink(heading);
+        // Collapse the inline TOC after a jump so it doesn't cover the content.
+        inlineLink.addEventListener('click', () => {
+          if (inlineDetails) inlineDetails.open = false;
+        });
+        tocInlineNav.appendChild(inlineLink);
       }
-      tocNav.appendChild(link);
     });
 
-    // Scroll-spy: highlight current section
+    if (!tocNav) return;
+
+    // Scroll-spy: highlight current section (desktop sidebar only)
     const tocLinks = tocNav.querySelectorAll('a');
     const observer = new IntersectionObserver(
       (entries) => {

--- a/blog-src/src/pages/blog/series/[series].astro
+++ b/blog-src/src/pages/blog/series/[series].astro
@@ -1,0 +1,256 @@
+---
+import type { GetStaticPaths } from 'astro';
+import { getCollection } from 'astro:content';
+import BlogLayout from '../../../layouts/BlogLayout.astro';
+import { SITE_URL } from '../../../config';
+import { getReadTime } from '../../../utils/readTime';
+import { formatDateShort } from '../../../utils/format';
+import { slugify } from '../../../utils/slug';
+
+export const getStaticPaths = (async () => {
+  const posts = await getCollection('posts');
+  const seriesMap = new Map<string, { name: string; posts: typeof posts }>();
+  for (const post of posts) {
+    const name = post.data.series;
+    if (!name) continue;
+    const key = slugify(name);
+    if (!seriesMap.has(key)) seriesMap.set(key, { name, posts: [] });
+    seriesMap.get(key)!.posts.push(post);
+  }
+  return [...seriesMap.entries()].map(([series, { name, posts: seriesPosts }]) => ({
+    params: { series },
+    props: {
+      seriesName: name,
+      posts: seriesPosts.sort((a, b) => {
+        const ao = a.data.seriesOrder ?? Number.POSITIVE_INFINITY;
+        const bo = b.data.seriesOrder ?? Number.POSITIVE_INFINITY;
+        if (ao !== bo) return ao - bo;
+        return a.data.date.valueOf() - b.data.date.valueOf();
+      }),
+    },
+  }));
+}) satisfies GetStaticPaths;
+
+const { seriesName, posts } = Astro.props;
+const siteUrl = SITE_URL;
+
+const breadcrumbSchema = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": siteUrl },
+    { "@type": "ListItem", "position": 2, "name": "Blog", "item": `${siteUrl}/blog/` },
+    { "@type": "ListItem", "position": 3, "name": seriesName, "item": `${siteUrl}/blog/series/${slugify(seriesName)}/` },
+  ],
+});
+---
+
+<BlogLayout
+  title={`Series: ${seriesName}`}
+  description={`A ${posts.length}-part series: "${seriesName}".`}
+>
+  <Fragment slot="head">
+    <script type="application/ld+json" set:html={breadcrumbSchema} />
+  </Fragment>
+  <div class="listing-wrapper">
+    <nav class="breadcrumbs" aria-label="Breadcrumb">
+      <a href="/">Home</a>
+      <span class="breadcrumb-sep">/</span>
+      <a href="/blog/">Blog</a>
+      <span class="breadcrumb-sep">/</span>
+      <span class="breadcrumb-current">{seriesName}</span>
+    </nav>
+
+    <p class="series-eyebrow">Series</p>
+    <h1>{seriesName}</h1>
+    <p class="taxonomy-count">{posts.length} part{posts.length === 1 ? '' : 's'}</p>
+
+    <ol class="series-list">
+      {posts.map((post, i) => {
+        const readTime = getReadTime(post.body);
+        return (
+          <li>
+            <a href={`/blog/${post.id}/`} class="series-item">
+              <span class="series-item-num">{i + 1}</span>
+              <span class="series-item-body">
+                <span class="series-item-title">{post.data.title}</span>
+                <span class="series-item-meta">
+                  <time datetime={post.data.date.toISOString()}>
+                    {formatDateShort(post.data.date)}
+                  </time>
+                  <span class="dot-sep">&middot;</span>
+                  <span>{readTime} min read</span>
+                </span>
+                <span class="series-item-excerpt">{post.data.excerpt}</span>
+              </span>
+            </a>
+          </li>
+        );
+      })}
+    </ol>
+
+    <div class="back-link">
+      <a href="/blog/">&larr; All posts</a>
+    </div>
+  </div>
+</BlogLayout>
+
+<style>
+  .listing-wrapper {
+    max-width: 720px;
+    margin: 0 auto;
+  }
+
+  @media (min-width: 768px) {
+    .listing-wrapper { max-width: 900px; }
+  }
+
+  .breadcrumbs {
+    font-family: 'Poppins', sans-serif;
+    font-size: 13px;
+    color: #9ca3af;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .breadcrumbs a { color: #6b7280; text-decoration: none; transition: color 0.2s; }
+  .breadcrumbs a:hover { color: #2980b9; }
+  .breadcrumb-sep { color: #d1d5db; }
+  .breadcrumb-current { color: #374151; font-weight: 500; }
+
+  .series-eyebrow {
+    font-family: 'Poppins', sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #2980b9;
+    margin: 0 0 4px;
+  }
+
+  h1 {
+    font-family: 'Poppins', sans-serif;
+    font-size: 28px;
+    font-weight: 700;
+    color: #111827;
+    margin: 0 0 4px;
+  }
+
+  .taxonomy-count {
+    font-family: 'Poppins', sans-serif;
+    font-size: 15px;
+    color: #6b7280;
+    margin-bottom: 32px;
+  }
+
+  .series-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    counter-reset: none;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .series-item {
+    display: flex;
+    gap: 18px;
+    align-items: flex-start;
+    padding: 20px 22px;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    text-decoration: none;
+    transition: all 0.2s;
+  }
+
+  .series-item:hover {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+    border-color: #d1d5db;
+    transform: translateY(-2px);
+  }
+
+  .series-item-num {
+    font-family: 'Poppins', sans-serif;
+    font-size: 16px;
+    font-weight: 700;
+    color: #2980b9;
+    background: rgba(41, 128, 185, 0.08);
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .series-item-body { min-width: 0; display: block; }
+
+  .series-item-title {
+    display: block;
+    font-family: 'Poppins', sans-serif;
+    font-size: 17px;
+    font-weight: 700;
+    color: #111827;
+    line-height: 1.35;
+  }
+
+  .series-item-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-family: 'Poppins', sans-serif;
+    font-size: 13px;
+    color: #9ca3af;
+    margin: 4px 0 8px;
+  }
+
+  .dot-sep { color: #d1d5db; }
+
+  .series-item-excerpt {
+    display: block;
+    font-family: 'Poppins', sans-serif;
+    font-size: 14px;
+    color: #6b7280;
+    line-height: 1.6;
+  }
+
+  .back-link {
+    margin-top: 40px;
+    padding-top: 16px;
+    border-top: 1px solid #e5e7eb;
+  }
+
+  .back-link a {
+    font-family: 'Poppins', sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    color: #2980b9;
+    text-decoration: none;
+  }
+  .back-link a:hover { opacity: 0.7; }
+
+  @media (prefers-color-scheme: dark) {
+    h1 { color: #f1f5f9; }
+    .series-eyebrow { color: #60a5fa; }
+    .taxonomy-count { color: #94a3b8; }
+    .breadcrumbs a { color: #94a3b8; }
+    .breadcrumbs a:hover { color: #60a5fa; }
+    .breadcrumb-sep { color: #475569; }
+    .breadcrumb-current { color: #e2e8f0; }
+    .series-item { background: #1e293b; border-color: #334155; }
+    .series-item:hover { box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); border-color: #475569; }
+    .series-item-num { color: #60a5fa; background: rgba(96, 165, 250, 0.12); }
+    .series-item-title { color: #f1f5f9; }
+    .series-item-meta { color: #64748b; }
+    .dot-sep { color: #475569; }
+    .series-item-excerpt { color: #94a3b8; }
+    .back-link { border-top-color: #334155; }
+    .back-link a { color: #60a5fa; }
+  }
+</style>

--- a/blog-src/src/pages/feed.json.ts
+++ b/blog-src/src/pages/feed.json.ts
@@ -1,0 +1,37 @@
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+import { SITE_URL } from '../config';
+
+// JSON Feed 1.1 — https://www.jsonfeed.org/version/1.1/
+// Companion to /blog/rss.xml for readers that prefer JSON.
+export async function GET(_context: APIContext) {
+  const posts = (await getCollection('posts')).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  );
+
+  const feed = {
+    version: 'https://jsonfeed.org/version/1.1',
+    title: "Michael LaPlante's Blog",
+    home_page_url: `${SITE_URL}/blog/`,
+    feed_url: `${SITE_URL}/feed.json`,
+    description: 'Thoughts on security, engineering, and building things.',
+    language: 'en-US',
+    authors: [{ name: 'Michael LaPlante', url: SITE_URL }],
+    items: posts.map((post) => ({
+      id: `${SITE_URL}/blog/${post.id}/`,
+      url: `${SITE_URL}/blog/${post.id}/`,
+      title: post.data.title,
+      summary: post.data.excerpt,
+      content_text: post.data.excerpt,
+      date_published: post.data.date.toISOString(),
+      date_modified: (post.data.updated ?? post.data.date).toISOString(),
+      tags: [post.data.category, ...post.data.tags],
+    })),
+  };
+
+  return new Response(JSON.stringify(feed, null, 2), {
+    headers: {
+      'Content-Type': 'application/feed+json; charset=utf-8',
+    },
+  });
+}

--- a/blog-src/src/pages/index.astro
+++ b/blog-src/src/pages/index.astro
@@ -3,7 +3,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 import { getCollection } from 'astro:content';
 import { getReadTime } from '../utils/readTime';
 import { formatDateShort } from '../utils/format';
-import { profile, summary, stats, skills, experience } from '../data/resume';
+import { profile, summary, stats, skills, experience, certifications } from '../data/resume';
 
 const posts = (await getCollection('posts'))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
@@ -282,6 +282,38 @@ const posts = (await getCollection('posts'))
 
     </div>
   </section>
+
+  {certifications.length > 0 && (
+  <!--========================================
+    Certifications Section
+  =========================================-->
+  <section class="section skills-section" id="certifications">
+    <div class="container">
+
+      <div class="section-header" data-aos="fade-up">
+        <h2>Certifications</h2>
+      </div>
+
+      <div class="row">
+        {certifications.map((cert) => (
+          <div class="col-sm-6 col-md-4" data-aos="fade-up">
+            <div class="service">
+              <h4>
+                {cert.url ? (
+                  <a href={cert.url} target="_blank" rel="noopener noreferrer">{cert.name}</a>
+                ) : (
+                  cert.name
+                )}
+              </h4>
+              <p>{cert.issuer}{cert.year ? ` · ${cert.year}` : ''}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+    </div>
+  </section>
+  )}
 
   <!--========================================
     Experience Section

--- a/blog-src/src/pages/index.astro
+++ b/blog-src/src/pages/index.astro
@@ -100,7 +100,7 @@ const posts = (await getCollection('posts'))
             <a data-scroll href="#about">About</a>
           </li>
           <li>
-            <a data-scroll href="#services">Services</a>
+            <a href="/services/">Services</a>
           </li>
           <li>
             <a data-scroll href="#skills">Skills</a>

--- a/blog-src/src/pages/index.astro
+++ b/blog-src/src/pages/index.astro
@@ -253,8 +253,9 @@ const posts = (await getCollection('posts'))
         </div>
       </div>
 
-      <div class="text-center" data-aos="fade-up" style="margin-top: 24px;">
+      <div class="text-center intro-actions" data-aos="fade-up" style="margin-top: 24px;">
         <a href="#contact" data-scroll class="btn btn-custom">Discuss Your Needs</a>
+        <a href="/services/" class="btn btn-custom btn-ghost">See Full Services &rarr;</a>
       </div>
     </div>
   </section>

--- a/blog-src/src/pages/resume.astro
+++ b/blog-src/src/pages/resume.astro
@@ -1,6 +1,6 @@
 ---
 import SiteLayout from '../layouts/SiteLayout.astro';
-import { profile, summary, stats, skills, experience } from '../data/resume';
+import { profile, summary, stats, skills, experience, certifications } from '../data/resume';
 ---
 
 <SiteLayout
@@ -40,6 +40,7 @@ import { profile, summary, stats, skills, experience } from '../data/resume';
       <div class="menu" role="menu">
         <ul>
           <li><a href="/">Home</a></li>
+          <li><a href="/services/">Services</a></li>
           <li><a href="/blog/">Blog</a></li>
           <li><a href="/uses/">Uses</a></li>
           <li><a href="/resume/">Resume</a></li>
@@ -94,6 +95,20 @@ import { profile, summary, stats, skills, experience } from '../data/resume';
           ))}
         </div>
       </section>
+
+      {certifications.length > 0 && (
+        <section class="resume-section">
+          <h2>Certifications</h2>
+          <ul class="resume-certs">
+            {certifications.map((cert) => (
+              <li>
+                <strong>{cert.name}</strong>
+                <span> · {cert.issuer}{cert.year ? ` · ${cert.year}` : ''}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       <section class="resume-section">
         <h2>Experience</h2>
@@ -280,6 +295,26 @@ import { profile, summary, stats, skills, experience } from '../data/resume';
     margin: 0;
   }
 
+  .resume-certs {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 28px;
+  }
+  .resume-certs li {
+    font-family: 'Poppins', sans-serif;
+    font-size: 13px;
+    color: #374151;
+    line-height: 1.5;
+  }
+  .resume-certs strong {
+    font-weight: 600;
+    color: #111827;
+  }
+  .resume-certs span { color: #6b7280; }
+
   .resume-job {
     margin-bottom: 20px;
   }
@@ -314,6 +349,7 @@ import { profile, summary, stats, skills, experience } from '../data/resume';
   @media (max-width: 600px) {
     .resume-paper { padding: 32px 22px; }
     .resume-skills { grid-template-columns: 1fr; }
+    .resume-certs { grid-template-columns: 1fr; }
     .resume-job-head { flex-direction: column; gap: 2px; }
   }
 

--- a/blog-src/src/pages/services.astro
+++ b/blog-src/src/pages/services.astro
@@ -1,0 +1,269 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+import { stats } from '../data/resume';
+import { SITE_URL } from '../config';
+
+const services = [
+  {
+    icon: 'icon-basic-shield',
+    title: 'Security Architecture Reviews',
+    description:
+      'Assess your infrastructure, identify gaps, and design defense-in-depth strategies tailored to your risk profile and compliance requirements.',
+  },
+  {
+    icon: 'icon-basic-cloud',
+    title: 'Cloud Security Strategy',
+    description:
+      'Build secure multi-cloud architectures across AWS, Azure, and GCP with zero-trust principles, least-privilege access, and continuous monitoring.',
+  },
+  {
+    icon: 'icon-basic-lock',
+    title: 'Compliance & Risk Assessment',
+    description:
+      'Navigate SOC 2, ISO 27001, HIPAA, and PCI-DSS with practical frameworks that satisfy auditors without slowing your teams down.',
+  },
+  {
+    icon: 'icon-basic-lightbulb',
+    title: 'Engineering Leadership Advisory',
+    description:
+      'Scale engineering organizations, establish DevSecOps practices, and build the security culture that keeps your company out of the headlines.',
+  },
+];
+
+const process = [
+  {
+    step: '01',
+    title: 'Discovery',
+    description:
+      'A focused conversation about your systems, risks, and goals — so any engagement starts grounded in your actual environment, not a template.',
+  },
+  {
+    step: '02',
+    title: 'Assessment',
+    description:
+      'A hands-on review of architecture, controls, and processes, surfacing the gaps that matter most and the ones safe to defer.',
+  },
+  {
+    step: '03',
+    title: 'Roadmap',
+    description:
+      'A prioritized, pragmatic plan your team can actually execute — sequenced by risk reduction and business impact, not checklist completeness.',
+  },
+  {
+    step: '04',
+    title: 'Partnership',
+    description:
+      'Ongoing advisory through implementation: design reviews, threat modeling, and leadership support as the plan becomes reality.',
+  },
+];
+
+const professionalServiceSchema = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "ProfessionalService",
+  "name": "LaPlante Web Development",
+  "image": "https://michaellaplante.com/images/mike-laplante-400.jpg",
+  "url": `${SITE_URL}/services/`,
+  "description":
+    "Independent security consulting: security architecture reviews, cloud security strategy, compliance & risk assessment, and engineering leadership advisory.",
+  "areaServed": "Worldwide",
+  "availableLanguage": "English",
+  "serviceType": services.map((s) => s.title),
+  "founder": {
+    "@type": "Person",
+    "name": "Michael LaPlante",
+    "url": SITE_URL,
+  },
+  "provider": {
+    "@type": "Person",
+    "name": "Michael LaPlante",
+    "url": SITE_URL,
+  },
+  "sameAs": [
+    "https://www.linkedin.com/in/mlaplante/",
+    "https://github.com/mlaplante",
+    "https://twitter.com/laplantewebdev",
+  ],
+});
+---
+
+<SiteLayout
+  title="Consulting Services | Michael LaPlante - Security Architecture, Cloud Security & Compliance"
+  description="Security consulting by Michael LaPlante — security architecture reviews, cloud security strategy, compliance & risk assessment, and engineering leadership advisory. 15+ years in enterprise security."
+>
+  <Fragment slot="head">
+    <meta name="keywords" content="security consulting, cloud security consultant, security architecture review, SOC 2, ISO 27001, DevSecOps advisory, Michael LaPlante">
+    <meta name="author" content="Michael LaPlante">
+    <script type="application/ld+json" set:html={professionalServiceSchema} />
+    <link rel="stylesheet" type="text/css" href="/css/fonts.css">
+    <link rel="stylesheet" href="/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="/css/linea.css">
+    <link rel="stylesheet" type="text/css" href="/css/style.css">
+  </Fragment>
+
+  <!-- Skip to Content Link for Accessibility -->
+  <a href="#main-content" class="skip-to-content">Skip to main content</a>
+
+  <!--========================================
+    Menu
+  =========================================-->
+  <nav class="top-nav" aria-label="Main navigation">
+    <div class="container">
+
+      <a href="#" class="menu-btn" aria-label="Toggle menu" aria-expanded="false">
+        <span class="lines">
+          <span class="l1"></span>
+          <span class="l2"></span>
+          <span class="l3"></span>
+        </span>
+      </a>
+
+      <button class="dark-mode-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+        <span class="sun-icon">☀️</span>
+        <span class="moon-icon">🌙</span>
+      </button>
+
+      <div class="menu" role="menu">
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="/services/">Services</a></li>
+          <li><a href="/blog/">Blog</a></li>
+          <li><a href="/uses/">Uses</a></li>
+          <li><a href="/resume/">Resume</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <!--========================================
+    Main Content
+  =========================================-->
+  <main id="main-content">
+
+  <!-- Page Header -->
+  <section class="section" id="services-header" style="padding-top: 120px;">
+    <div class="container">
+      <div class="section-header" data-aos="fade-up">
+        <h1>Consulting Services</h1>
+      </div>
+      <p data-aos="fade-up">
+        I help teams build secure, scalable systems — drawing on 15+ years across
+        information security, engineering leadership, and software development.
+        Engagements are pragmatic and tailored to your environment, not a
+        one-size-fits-all checklist.
+      </p>
+      <div data-aos="fade-up" style="margin-top: 20px;">
+        <a href="/#contact" class="btn btn-custom">Schedule a Consultation</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Services -->
+  <section class="section" id="what-i-do">
+    <div class="container">
+      <div class="section-header" data-aos="fade-up">
+        <h2>What I Do</h2>
+      </div>
+      <div class="row">
+        {services.map((service) => (
+          <div class="col-sm-6">
+            <div class="service" data-aos="fade-up">
+              <i class={service.icon}></i>
+              <h4>{service.title}</h4>
+              <p>{service.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Process -->
+  <section class="section" id="how-it-works">
+    <div class="container">
+      <div class="section-header" data-aos="fade-up">
+        <h2>How Engagements Work</h2>
+      </div>
+      <div class="row">
+        {process.map((phase) => (
+          <div class="col-sm-6 col-md-3">
+            <div class="service" data-aos="fade-up">
+              <span class="process-step">{phase.step}</span>
+              <h4>{phase.title}</h4>
+              <p>{phase.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- By the Numbers -->
+  <section class="section funfacts-section" id="funfacts">
+    <div class="container">
+      <div class="section-header" data-aos="fade-up">
+        <h2>Why Work With Me</h2>
+      </div>
+      <div class="row">
+        {stats.map((stat) => (
+          <div class="col-sm-3 col-6">
+            <div class="funfact" data-aos="fade-up">
+              <strong>{stat.value}</strong>
+              <span>{stat.label}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="section" id="services-cta">
+    <div class="container">
+      <div class="section-header" data-aos="fade-up">
+        <h2>Let's Talk</h2>
+      </div>
+      <p data-aos="fade-up">
+        Have a security challenge, an upcoming audit, or a team you want to level
+        up? Tell me what you're working on and I'll get back to you.
+      </p>
+      <div data-aos="fade-up" style="margin-top: 20px;">
+        <a href="/#contact" class="btn btn-custom">Get In Touch</a>
+      </div>
+    </div>
+  </section>
+
+  </main>
+
+  <!--========================================
+    Footer
+  =========================================-->
+  <footer>
+    <div class="container">
+      <p class="copyright" data-aos="fade-up">
+        Copyright &copy; LaPlante Web Development 2006-<span id="copyright-year"></span>.
+        <a href="/privacy/">Privacy</a>
+      </p>
+    </div>
+  </footer>
+
+  <!--========================================
+    JavaScript Files
+  =========================================-->
+  <script is:inline src="/js/script.js"></script>
+</SiteLayout>
+
+<style>
+  .process-step {
+    display: inline-block;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 22px;
+    font-weight: 700;
+    color: #2980b9;
+    margin-bottom: 8px;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .process-step { color: #60a5fa; }
+  }
+  :global(body.dark-mode) .process-step { color: #60a5fa; }
+</style>

--- a/blog-src/src/pages/uses.astro
+++ b/blog-src/src/pages/uses.astro
@@ -37,6 +37,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
       <div class="menu" role="menu">
         <ul>
           <li><a href="/">Home</a></li>
+          <li><a href="/services/">Services</a></li>
           <li><a href="/blog/">Blog</a></li>
           <li><a href="/uses/">Uses</a></li>
           <li><a href="/resume/">Resume</a></li>

--- a/blog-src/src/styles/blog.css
+++ b/blog-src/src/styles/blog.css
@@ -67,6 +67,19 @@ body {
 .blog-nav .nav-links {
   display: flex;
   gap: 24px;
+  flex-wrap: wrap;
+}
+
+/* Keep the wider nav from overflowing on narrow screens. */
+@media (max-width: 640px) {
+  .blog-nav .container {
+    flex-wrap: wrap;
+    gap: 6px 16px;
+  }
+  .blog-nav .nav-links {
+    gap: 14px;
+    row-gap: 6px;
+  }
 }
 
 /* ===== Content Area ===== */

--- a/blog-src/src/utils/slug.ts
+++ b/blog-src/src/utils/slug.ts
@@ -1,0 +1,8 @@
+// URL-safe slug from an arbitrary label (series names, etc.). Mirrors the
+// slugify in scripts/lib/blog-post.js so routes and links stay in sync.
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}

--- a/scripts/lib/blog-post.js
+++ b/scripts/lib/blog-post.js
@@ -355,14 +355,21 @@ export function makeExcerpt(content) {
     .trim() + '...';
 }
 
-export function buildFrontmatter({ title, date, category, excerpt }) {
+// Optionally groups a post into a multi-part series. When `series` is supplied
+// the lines are emitted as real frontmatter; otherwise a commented hint is left
+// so a human reviewer can opt the draft into a series at publish time. The hint
+// is a YAML comment, so it's ignored by the content-collection schema either way.
+export function buildFrontmatter({ title, date, category, excerpt, series, seriesOrder }) {
   const esc = (s) => s.replace(/"/g, '\\"');
+  const seriesLines = series
+    ? `series: "${esc(series)}"\nseriesOrder: ${Number.isFinite(seriesOrder) ? seriesOrder : 1}\n`
+    : `# series: ""      # optional: set the same value on every part of a multi-part series\n# seriesOrder: 1   # this post's position within that series\n`;
   return `---
 title: "${esc(title)}"
 date: ${date}
 category: "${category}"
 tags: []
-excerpt: "${esc(excerpt)}"
+${seriesLines}excerpt: "${esc(excerpt)}"
 ---`;
 }
 

--- a/tests/lib/blog-post.test.js
+++ b/tests/lib/blog-post.test.js
@@ -136,6 +136,33 @@ describe('buildFrontmatter', () => {
     expect(fm.startsWith('---\n')).toBe(true);
     expect(fm.endsWith('---')).toBe(true);
   });
+
+  it('emits a commented series hint when no series is supplied', () => {
+    const fm = buildFrontmatter({
+      title: 'A Post',
+      date: '2026-05-17',
+      category: 'thought-leadership',
+      excerpt: 'Body',
+    });
+    expect(fm).toContain('# series:');
+    expect(fm).toContain('# seriesOrder:');
+    // The hint must be a YAML comment, never active frontmatter.
+    expect(fm).not.toMatch(/^series:/m);
+  });
+
+  it('emits real series frontmatter when a series is supplied', () => {
+    const fm = buildFrontmatter({
+      title: 'A Post',
+      date: '2026-05-17',
+      category: 'thought-leadership',
+      excerpt: 'Body',
+      series: 'Zero Trust Deep Dive',
+      seriesOrder: 2,
+    });
+    expect(fm).toMatch(/^series: "Zero Trust Deep Dive"$/m);
+    expect(fm).toMatch(/^seriesOrder: 2$/m);
+    expect(fm).not.toContain('# series:');
+  });
 });
 
 describe('findMostSimilar (lexical Jaccard)', () => {


### PR DESCRIPTION
Implements several portfolio/blog gaps:

- Certifications (#5): adds a Certification type + empty `certifications`
  array to the shared resume data; homepage and résumé render a
  Certifications section only when it's non-empty, so nothing ships until
  real credentials are supplied.
- Services page (#6): new /services with offerings, engagement process,
  and a ProfessionalService JSON-LD block (#18) for the consulting side.
- Author bio (#10): AuthorBio component rendered at the foot of every post.
- Mobile TOC (#11): adds a collapsible inline table of contents for narrow
  viewports (the desktop sidebar TOC already existed); one heading pass now
  populates both.
- Series (#13): optional `series`/`seriesOrder` frontmatter, a per-post
  series box, and /blog/series/<slug> index pages. buildFrontmatter emits a
  commented series hint on auto-generated drafts so reviewers can opt a post
  into a series at publish time.
- Nav unification (#15): Services/Uses/Résumé exposed consistently across the
  site and blog navs, with responsive wrapping for the wider blog nav.
- JSON Feed (#16): /feed.json (JSON Feed 1.1) alongside RSS, with
  autodiscovery in BaseHead.

Adds buildFrontmatter series tests; full build + 51 tests pass.

https://claude.ai/code/session_011wZak1gBtm5cPJr3bKHqxC