### PR TITLE
Fix mobile blog navigation with collapsible hamburger menu

### DIFF
--- a/blog-src/src/layouts/BlogLayout.astro
+++ b/blog-src/src/layouts/BlogLayout.astro
@@ -48,8 +48,19 @@ const fullTitle = `${title} | Michael LaPlante`;
     )}
     <nav class="blog-nav" aria-label="Blog navigation">
       <div class="container">
-        <a href="/">Michael LaPlante</a>
-        <div class="nav-links">
+        <a href="/" class="nav-brand">Michael LaPlante</a>
+        <button
+          class="nav-toggle"
+          type="button"
+          aria-label="Toggle navigation menu"
+          aria-expanded="false"
+          aria-controls="blog-nav-links"
+        >
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+        </button>
+        <div class="nav-links" id="blog-nav-links">
           <a href="/">Home</a>
           <a href="/services/">Services</a>
           <a href={baseUrl}>Blog</a>
@@ -60,6 +71,25 @@ const fullTitle = `${title} | Michael LaPlante`;
         </div>
       </div>
     </nav>
+    <script is:inline>
+      (function () {
+        var nav = document.querySelector('.blog-nav');
+        if (!nav) return;
+        var toggle = nav.querySelector('.nav-toggle');
+        if (!toggle) return;
+        toggle.addEventListener('click', function () {
+          var open = nav.classList.toggle('nav-open');
+          toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+        });
+        // Close the menu when a link is tapped.
+        nav.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () {
+            nav.classList.remove('nav-open');
+            toggle.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
     <main id="blog-main-content" class="blog-content">
       <slot />
     </main>

--- a/blog-src/src/styles/blog.css
+++ b/blog-src/src/styles/blog.css
@@ -70,15 +70,69 @@ body {
   flex-wrap: wrap;
 }
 
-/* Keep the wider nav from overflowing on narrow screens. */
+/* Hamburger toggle — hidden on desktop, shown on narrow screens. */
+.blog-nav .nav-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 40px;
+  height: 40px;
+  padding: 8px;
+  margin: -8px;
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
+.blog-nav .nav-toggle-bar {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: #fff;
+  border-radius: 2px;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+/* Collapse the nav into a tappable menu on narrow screens. */
 @media (max-width: 640px) {
-  .blog-nav .container {
-    flex-wrap: wrap;
-    gap: 6px 16px;
+  .blog-nav .nav-toggle {
+    display: flex;
   }
   .blog-nav .nav-links {
-    gap: 14px;
-    row-gap: 6px;
+    flex-basis: 100%;
+    flex-direction: column;
+    gap: 0;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.25s ease;
+  }
+  .blog-nav.nav-open .nav-links {
+    max-height: 360px;
+    margin-top: 12px;
+  }
+  .blog-nav .nav-links a {
+    display: block;
+    padding: 12px 4px;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    font-size: 15px;
+  }
+  /* Morph the bars into an X when open. */
+  .blog-nav.nav-open .nav-toggle-bar:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+  }
+  .blog-nav.nav-open .nav-toggle-bar:nth-child(2) {
+    opacity: 0;
+  }
+  .blog-nav.nav-open .nav-toggle-bar:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blog-nav .nav-links,
+  .blog-nav .nav-toggle-bar {
+    transition: none;
   }
 }
 

--- a/blog-src/src/styles/blog.css
+++ b/blog-src/src/styles/blog.css
@@ -96,8 +96,13 @@ body {
 
 /* Collapse the nav into a tappable menu on narrow screens. */
 @media (max-width: 640px) {
+  /* Let the links wrap onto their own full-width row below the bar. */
+  .blog-nav .container {
+    flex-wrap: wrap;
+  }
   .blog-nav .nav-toggle {
     display: flex;
+    margin-left: auto;
   }
   .blog-nav .nav-links {
     flex-basis: 100%;


### PR DESCRIPTION
The blog nav links wrapped awkwardly onto two cramped rows on narrow
screens. Replace the wrapping behavior with a hamburger toggle that
collapses the links into a clean, tappable vertical dropdown on mobile
(<=640px), while keeping the horizontal layout on larger screens.