### PR TITLE
Add upstream timeouts and improve error handling & security

### DIFF
--- a/.github/workflows/publish-blog-post.yml
+++ b/.github/workflows/publish-blog-post.yml
@@ -26,7 +26,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-      actions: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,14 @@ dist/
 blog-src/node_modules/
 blog-src/.astro/
 
+# Local secrets — .env for Astro PUBLIC_ vars, .dev.vars for `wrangler dev`.
+# Only the example template is tracked.
+.env
+.env.*
+!.env.example
+.dev.vars
+.dev.vars.*
+
 # Local cache of LLM embeddings used by the auto-blog-draft dedupe pipeline.
 scripts/.embeddings-cache.json
 blog/**/CLAUDE.md

--- a/blog-src/astro.config.mjs
+++ b/blog-src/astro.config.mjs
@@ -18,6 +18,15 @@ export default defineConfig({
     },
   },
   integrations: [sitemap()],
+  vite: {
+    build: {
+      // Never inline bundled <script> blocks into the HTML. Required for the
+      // strict CSP in public/_headers (script-src without 'unsafe-inline'):
+      // with the default 4KB limit, small page scripts get embedded as inline
+      // <script type="module"> and would be blocked.
+      assetsInlineLimit: 0,
+    },
+  },
   markdown: {
     shikiConfig: {
       themes: {

--- a/blog-src/public/_headers
+++ b/blog-src/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://laplantedevanalytics.netlify.app https://static.cloudflareinsights.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://laplantedevanalytics.netlify.app; frame-src https://challenges.cloudflare.com; form-action 'self' https://buttondown.com; base-uri 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://laplantedevanalytics.netlify.app https://static.cloudflareinsights.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://laplantedevanalytics.netlify.app; frame-src https://challenges.cloudflare.com; form-action 'self' https://buttondown.com; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; upgrade-insecure-requests
   Cache-Control: public, max-age=0, must-revalidate
   CDN-Cache-Control: public, max-age=3600, stale-while-revalidate=86400
 

--- a/blog-src/public/js/blog-nav.js
+++ b/blog-src/public/js/blog-nav.js
@@ -1,0 +1,29 @@
+/* Blog nav hamburger toggle. Kept as an external file (rather than an inline
+   <script>) so the site CSP can serve script-src without 'unsafe-inline'. */
+(function () {
+	'use strict';
+
+	function init() {
+		var nav = document.querySelector('.blog-nav');
+		if (!nav) return;
+		var toggle = nav.querySelector('.nav-toggle');
+		if (!toggle) return;
+		toggle.addEventListener('click', function () {
+			var open = nav.classList.toggle('nav-open');
+			toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+		});
+		// Close the menu when a link is tapped.
+		nav.querySelectorAll('.nav-links a').forEach(function (link) {
+			link.addEventListener('click', function () {
+				nav.classList.remove('nav-open');
+				toggle.setAttribute('aria-expanded', 'false');
+			});
+		});
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', init);
+	} else {
+		init();
+	}
+})();

--- a/blog-src/public/js/resume-print.js
+++ b/blog-src/public/js/resume-print.js
@@ -1,0 +1,11 @@
+/* Print button on /resume. External file (rather than an inline <script>) so
+   the site CSP can serve script-src without 'unsafe-inline'. */
+(function () {
+	'use strict';
+	var btn = document.getElementById('resume-print');
+	if (btn) {
+		btn.addEventListener('click', function () {
+			window.print();
+		});
+	}
+})();

--- a/blog-src/src/layouts/BlogLayout.astro
+++ b/blog-src/src/layouts/BlogLayout.astro
@@ -71,25 +71,8 @@ const fullTitle = `${title} | Michael LaPlante`;
         </div>
       </div>
     </nav>
-    <script is:inline>
-      (function () {
-        var nav = document.querySelector('.blog-nav');
-        if (!nav) return;
-        var toggle = nav.querySelector('.nav-toggle');
-        if (!toggle) return;
-        toggle.addEventListener('click', function () {
-          var open = nav.classList.toggle('nav-open');
-          toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
-        });
-        // Close the menu when a link is tapped.
-        nav.querySelectorAll('.nav-links a').forEach(function (link) {
-          link.addEventListener('click', function () {
-            nav.classList.remove('nav-open');
-            toggle.setAttribute('aria-expanded', 'false');
-          });
-        });
-      })();
-    </script>
+    <!-- External so the CSP can serve script-src without 'unsafe-inline'. -->
+    <script is:inline defer src="/js/blog-nav.js"></script>
     <main id="blog-main-content" class="blog-content">
       <slot />
     </main>

--- a/blog-src/src/pages/blog/[...page].astro
+++ b/blog-src/src/pages/blog/[...page].astro
@@ -447,10 +447,18 @@ const isFirstPage = page.currentPage === 1;
     return activeBtn?.getAttribute('data-category') || 'all';
   }
 
+  // Escapes for BOTH element and attribute contexts. The DOM-based
+  // textContent/innerHTML trick does not escape quotes, which would let a
+  // value containing `"` break out of an attribute like data-category below.
+  const HTML_ESCAPES: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  };
   function escapeHtml(value: string): string {
-    const div = document.createElement('div');
-    div.textContent = value;
-    return div.innerHTML;
+    return value.replace(/[&<>"']/g, (c) => HTML_ESCAPES[c]);
   }
 
   function renderResults(posts: IndexedPost[], query: string) {
@@ -467,11 +475,11 @@ const isFirstPage = page.currentPage === 1;
       resultsGrid.innerHTML = matches
         .map(
           (post) => `
-            <a href="${post.url}" class="post-card" data-category="${escapeHtml(post.category)}">
+            <a href="${escapeHtml(post.url)}" class="post-card" data-category="${escapeHtml(post.category)}">
               <div class="post-card-meta">
-                <time datetime="${post.dateISO}">${escapeHtml(post.dateShort)}</time>
+                <time datetime="${escapeHtml(post.dateISO)}">${escapeHtml(post.dateShort)}</time>
                 <span class="dot-sep">&middot;</span>
-                <span>${post.readTime} min read</span>
+                <span>${Number(post.readTime) || 1} min read</span>
               </div>
               <h2>${escapeHtml(post.title)}</h2>
               <p>${escapeHtml(post.excerpt)}</p>

--- a/blog-src/src/pages/resume.astro
+++ b/blog-src/src/pages/resume.astro
@@ -139,9 +139,8 @@ import { profile, summary, stats, skills, experience, certifications } from '../
   </footer>
 
   <script is:inline src="/js/script.js"></script>
-  <script is:inline>
-    document.getElementById('resume-print')?.addEventListener('click', () => window.print());
-  </script>
+  <!-- External so the CSP can serve script-src without 'unsafe-inline'. -->
+  <script is:inline defer src="/js/resume-print.js"></script>
 </SiteLayout>
 
 <style>

--- a/scripts/backfill-updated.js
+++ b/scripts/backfill-updated.js
@@ -24,7 +24,7 @@
  * frontmatter date and its first git commit.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -49,8 +49,12 @@ function parseFrontmatter(content) {
 // changes, ignoring renames and the original import commit.
 function lastContentCommit(file) {
   const rel = relative(REPO_ROOT, file);
-  const log = execSync(
-    `git log --follow --diff-filter=M --pretty=format:%H%x09%ai -- "${rel}"`,
+  // execFileSync with an argv array (and `--` before the path) so a post
+  // filename containing shell metacharacters can't inject a command or be
+  // mistaken for a git option.
+  const log = execFileSync(
+    'git',
+    ['log', '--follow', '--diff-filter=M', '--pretty=format:%H%x09%ai', '--', rel],
     { cwd: REPO_ROOT, encoding: 'utf-8' },
   ).trim();
   if (!log) return null;

--- a/scripts/lib/blog-post.js
+++ b/scripts/lib/blog-post.js
@@ -7,7 +7,7 @@
 // Everything else — git log gathering, topic selection, dedupe, frontmatter,
 // collision-safe file naming — lives here so the three scripts can't drift.
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { writeFileSync, readFileSync, mkdirSync, readdirSync, existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
@@ -63,7 +63,8 @@ export function topicUserPrompt(topic) {
 export function getGitLog(days = DEFAULT_DAYS) {
   try {
     const since = new Date(Date.now() - days * 86_400_000).toISOString().split('T')[0];
-    return execSync(`git log --since="${since}" --oneline --no-merges`, { encoding: 'utf-8' });
+    // execFileSync with an argv array: nothing is ever interpreted by a shell.
+    return execFileSync('git', ['log', `--since=${since}`, '--oneline', '--no-merges'], { encoding: 'utf-8' });
   } catch {
     return '';
   }

--- a/tests/worker/contact.test.ts
+++ b/tests/worker/contact.test.ts
@@ -16,8 +16,8 @@ declare module 'cloudflare:test' {
 const SITE = 'https://example.com';
 
 // Mirror of worker/schema.sql. Kept inline because the Workers sandbox
-// can't read the host filesystem; the duplication is checked against the
-// real file by the `keeps in sync with worker/schema.sql` test below.
+// can't read the host filesystem — keep the two in sync by hand when the
+// schema changes.
 const TEST_SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS submissions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -84,18 +84,24 @@ function makeContactRequest(overrides: {
 //   - Turnstile siteverify  → ok by default
 //   - ForwardEmail send     → ok by default
 // Pass overrides to simulate failures of individual upstreams.
-function stubUpstreams(opts: { turnstile?: boolean; forwardEmail?: { ok: boolean; status?: number; body?: string } } = {}) {
-  const turnstileOk = opts.turnstile ?? true;
+function stubUpstreams(opts: {
+  turnstile?: boolean | 'network-error' | 'malformed';
+  forwardEmail?: { ok: boolean; status?: number; body?: string } | 'network-error';
+} = {}) {
+  const turnstile = opts.turnstile ?? true;
   const feRes = opts.forwardEmail ?? { ok: true };
   const fetchSpy = vi.fn(async (input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
     if (url.includes('challenges.cloudflare.com/turnstile/v0/siteverify')) {
-      return new Response(JSON.stringify({ success: turnstileOk, 'error-codes': turnstileOk ? [] : ['invalid-input-response'] }), {
+      if (turnstile === 'network-error') throw new TypeError('fetch failed: connection refused');
+      if (turnstile === 'malformed') return new Response('<html>gateway error</html>', { status: 502 });
+      return new Response(JSON.stringify({ success: turnstile, 'error-codes': turnstile ? [] : ['invalid-input-response'] }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
     }
     if (url.includes('api.forwardemail.net/v1/emails')) {
+      if (feRes === 'network-error') throw new TypeError('fetch failed: connection refused');
       return new Response(feRes.body ?? (feRes.ok ? '{"id":"abc123"}' : '{"error":"bad"}'), {
         status: feRes.status ?? (feRes.ok ? 200 : 400),
       });
@@ -220,6 +226,26 @@ describe('contact form: turnstile', () => {
     expect(res.status).toBe(303);
     expect(res.headers.get('Location')).toBe(`${SITE}/contact-error/`);
   });
+
+  it('fails closed (redirect, no stored row) when siteverify is unreachable', async () => {
+    stubUpstreams({ turnstile: 'network-error' });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(makeContactRequest(), env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(303);
+    expect(res.headers.get('Location')).toBe(`${SITE}/contact-error/`);
+    const count = await env.DB.prepare('SELECT COUNT(*) AS n FROM submissions').first<{ n: number }>();
+    expect(count?.n).toBe(0);
+  });
+
+  it('fails closed when siteverify returns a non-JSON body', async () => {
+    stubUpstreams({ turnstile: 'malformed' });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(makeContactRequest(), env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(303);
+    expect(res.headers.get('Location')).toBe(`${SITE}/contact-error/`);
+  });
 });
 
 describe('contact form: honeypot', () => {
@@ -272,6 +298,19 @@ describe('contact form: rate limit', () => {
 describe('contact form: ForwardEmail upstream failure', () => {
   it('keeps the D1 row but redirects to /contact-error/', async () => {
     stubUpstreams({ forwardEmail: { ok: false, status: 502, body: '{"error":"upstream"}' } });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(makeContactRequest(), env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(303);
+    expect(res.headers.get('Location')).toBe(`${SITE}/contact-error/`);
+    const row = await env.DB.prepare(
+      'SELECT email FROM submissions WHERE email = ?1',
+    ).bind('test@example.com').first();
+    expect(row).not.toBeNull();
+  });
+
+  it('keeps the D1 row and redirects when ForwardEmail is unreachable', async () => {
+    stubUpstreams({ forwardEmail: 'network-error' });
     const ctx = createExecutionContext();
     const res = await worker.fetch(makeContactRequest(), env, ctx);
     await waitOnExecutionContext(ctx);

--- a/worker/api/contact.ts
+++ b/worker/api/contact.ts
@@ -10,6 +10,9 @@ const RETENTION_MS = 90 * 86_400_000;
 const MAX_NAME_LEN = 200;
 const MAX_EMAIL_LEN = 200;
 const MAX_MESSAGE_LEN = 5000;
+// Cap time spent waiting on Turnstile / ForwardEmail so a hung upstream
+// can't stall the request until the platform kills it.
+const UPSTREAM_TIMEOUT_MS = 10_000;
 
 // Strip CR/LF and other control characters that could be used to inject
 // extra email headers downstream when name/email are interpolated into
@@ -37,6 +40,12 @@ export async function handleContact(request: Request, env: Env, ctx: ExecutionCo
   const url = new URL(request.url);
   const redirectTo = (path: string) =>
     new Response(null, { status: 303, headers: { Location: url.origin + path, ...NO_STORE } });
+  // Log-and-bounce helper: every rejection path emits one structured warning
+  // and lands the user on the friendly error page.
+  const reject = (reason: string, details?: Record<string, unknown>) => {
+    console.warn(`contact: rejected on ${reason}`, details ?? {});
+    return redirectTo(CONTACT_ERROR);
+  };
 
   // Same-origin enforcement: every modern browser sends `Origin` on POST.
   // A legitimate form submission from this site matches `url.origin`.
@@ -63,13 +72,11 @@ export async function handleContact(request: Request, env: Env, ctx: ExecutionCo
   const token = String(form.get('cf-turnstile-response') ?? '');
 
   if (!name || !message || !EMAIL_RE.test(email)) {
-    console.warn('contact: rejected on validation', { hasName: !!name, hasMessage: !!message, emailOk: EMAIL_RE.test(email) });
-    return redirectTo(CONTACT_ERROR);
+    return reject('validation', { hasName: !!name, hasMessage: !!message, emailOk: EMAIL_RE.test(email) });
   }
 
   if (!token) {
-    console.warn('contact: rejected on missing turnstile token');
-    return redirectTo(CONTACT_ERROR);
+    return reject('missing turnstile token');
   }
 
   const ip = request.headers.get('CF-Connecting-IP') ?? '';
@@ -80,8 +87,7 @@ export async function handleContact(request: Request, env: Env, ctx: ExecutionCo
       'SELECT COUNT(*) AS n FROM submissions WHERE ip = ?1 AND ts > ?2'
     ).bind(ip, since).first<{ n: number }>();
     if (recent && recent.n >= RATE_LIMIT_MAX) {
-      console.warn('contact: rejected on rate limit', { ip, recent: recent.n });
-      return redirectTo(CONTACT_ERROR);
+      return reject('rate limit', { ip, recent: recent.n });
     }
   }
 
@@ -90,14 +96,22 @@ export async function handleContact(request: Request, env: Env, ctx: ExecutionCo
   tsBody.set('response', token);
   if (ip) tsBody.set('remoteip', ip);
 
-  const tsRes = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
-    method: 'POST',
-    body: tsBody,
-  });
-  const tsJson = (await tsRes.json()) as { success: boolean; 'error-codes'?: string[] };
+  // Fail closed: a siteverify outage, timeout, or malformed response means we
+  // could not verify the human — bounce to the error page instead of letting
+  // the exception surface as an opaque 500 (or worse, skipping verification).
+  let tsJson: { success: boolean; 'error-codes'?: string[] };
+  try {
+    const tsRes = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      body: tsBody,
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+    tsJson = (await tsRes.json()) as { success: boolean; 'error-codes'?: string[] };
+  } catch (err) {
+    return reject('turnstile verify error', { error: String(err) });
+  }
   if (!tsJson.success) {
-    console.warn('contact: rejected on turnstile', { errors: tsJson['error-codes'] });
-    return redirectTo(CONTACT_ERROR);
+    return reject('turnstile', { errors: tsJson['error-codes'] });
   }
 
   await env.DB.prepare(
@@ -121,14 +135,22 @@ export async function handleContact(request: Request, env: Env, ctx: ExecutionCo
     text: `From: ${name} <${email}>\nIP: ${ip}\n\n${message}`,
   });
 
-  const mailRes = await fetch('https://api.forwardemail.net/v1/emails', {
-    method: 'POST',
-    headers: {
-      Authorization: 'Basic ' + btoa(env.FE_API_KEY + ':'),
-      'Content-Type': 'application/json',
-    },
-    body: mailBody,
-  });
+  let mailRes: Response;
+  try {
+    mailRes = await fetch('https://api.forwardemail.net/v1/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic ' + btoa(env.FE_API_KEY + ':'),
+        'Content-Type': 'application/json',
+      },
+      body: mailBody,
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+  } catch (err) {
+    // Submission is already recorded in D1 as a backstop.
+    console.error('ForwardEmail fetch failed:', String(err));
+    return redirectTo(CONTACT_ERROR);
+  }
 
   if (!mailRes.ok) {
     const errBody = await mailRes.text();


### PR DESCRIPTION
## Summary
This PR hardens the contact form handler with timeout protection for upstream services, improves error handling consistency, and strengthens the site's Content Security Policy by externalizing inline scripts.

## Key Changes

### Contact Form Resilience
- **Upstream timeouts**: Added `UPSTREAM_TIMEOUT_MS` (10s) to both Turnstile siteverify and ForwardEmail API calls to prevent hung upstreams from stalling requests until platform timeout
- **Fail-closed verification**: Wrapped Turnstile verification in try-catch to gracefully handle network errors and malformed responses; rejects requests instead of surfacing opaque 500 errors
- **Consistent error handling**: Introduced `reject()` helper function to standardize logging and error responses across all rejection paths (validation, rate limit, Turnstile, etc.)
- **Graceful ForwardEmail failures**: ForwardEmail errors now redirect to error page while preserving the D1 submission as a backstop

### Security & CSP Compliance
- **Externalized scripts**: Moved inline `<script>` blocks from `BlogLayout.astro` and `resume.astro` to external files (`blog-nav.js`, `resume-print.js`) to support strict CSP without `'unsafe-inline'`
- **Vite build config**: Set `assetsInlineLimit: 0` to prevent Astro from inlining small bundled scripts, ensuring all scripts respect the CSP
- **CSP header update**: Removed `'unsafe-inline'` from `script-src` directive in `_headers`

### XSS Prevention
- **Improved HTML escaping**: Replaced DOM-based escaping in blog search with explicit character map covering both element and attribute contexts (prevents quote-based attribute breakout)
- **Attribute escaping**: Applied escaping to `href`, `datetime`, and other attributes in generated HTML
- **Input validation**: Added `Number()` coercion for `readTime` to prevent injection via malformed post data

### Code Quality
- **Shell injection prevention**: Replaced `execSync()` with `execFileSync()` in `backfill-updated.js` and `blog-post.js` to use argv arrays instead of shell string interpolation, preventing command injection via filenames
- **Test coverage**: Added tests for Turnstile network errors, malformed responses, and ForwardEmail unreachability
- **Documentation**: Updated comments in test schema and git log functions to clarify maintenance requirements

### Cleanup
- **Permissions**: Removed unnecessary `actions: write` permission from GitHub workflow
- **.gitignore**: Added `.env`, `.dev.vars`, and their variants to prevent accidental secret commits

## Notable Implementation Details
- Turnstile verification failures are logged with error details but don't store a D1 row (fail-closed approach)
- ForwardEmail failures preserve the D1 submission as a recovery mechanism since the email send is the last step
- The `reject()` helper ensures all error paths emit consistent structured warnings for observability
- External scripts use IIFE pattern and `defer` attribute for safe async loading without blocking page render

https://claude.ai/code/session_01TFf56eDsyUxb9mC3q1KNo5