### PR TITLE
Add Cal.com booking embed and build-time downloadable resume PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ A modern, fully Astro-powered personal portfolio and security consulting website
 - **Responsive Design**: Works seamlessly across desktop, tablet, and mobile
 - **Blog with Taxonomy**: Category, tag, and multi-part **series** pages, RSS + JSON feeds, related posts, per-post author bio, desktop + mobile tables of contents, dark mode, in-page reading progress
 - **Full-Archive Blog Search**: Client-side search over a build-time JSON index (`/blog/search.json`) covering every post, not just the current page
-- **Printable Résumé**: `/resume` renders a print-optimized résumé (browser "Save as PDF") from a single shared data module (`src/data/resume.ts`) that also powers the homepage experience/skills/certifications sections — one source of truth, no separate file to maintain
+- **Printable + Downloadable Résumé**: `/resume` renders a print-optimized résumé, and `/resume.pdf` is a true PDF generated at build time (pdfkit + the site's own Poppins fonts) — both driven by a single shared data module (`src/data/resume.ts`) that also powers the homepage experience/skills/certifications sections, so neither can drift from the site
 - **Consulting Services Page**: `/services` lays out the consulting offerings, engagement process, and a `ProfessionalService` structured-data block for the security-consulting side of the business
+- **Book-a-Call Scheduling**: Cal.com inline embed on `/services` (handle configured via `CAL_LINK` in `src/config.ts`; set it to `''` to hide all booking UI), with a CSP-compliant external bootstrap script, dark-mode-aware theming, and link-out fallbacks
 - **AI-Assisted Drafts**: Anthropic / Gemini / GitHub Models integrations for generating blog post drafts
 - **Automated Publishing**: GitHub Actions workflows to draft, promote, and deploy posts
 - **Performance Optimized**: Self-hosted assets, immutable cache headers for hashed bundles, CSS-only effects
@@ -68,7 +69,8 @@ resumesite/
 │       ├── styles/blog.css         # Blog-specific styles
 │       └── utils/
 │           ├── readTime.ts         # Word count / reading time
-│           └── format.ts           # Shared date formatting
+│           ├── format.ts           # Shared date formatting
+│           └── resumePdf.ts        # Build-time /resume.pdf renderer (pdfkit)
 ├── worker/                         # Cloudflare Worker for /api/contact
 │   ├── index.ts                    # Router
 │   ├── api/contact.ts              # Contact form handler (D1 + Turnstile + ForwardEmail)

--- a/blog-src/package-lock.json
+++ b/blog-src/package-lock.json
@@ -13,11 +13,13 @@
         "@astrojs/sitemap": "^3.7.3",
         "@resvg/resvg-js": "^2.6.2",
         "astro": "^6.4.4",
+        "pdfkit": "^0.19.1",
         "satori": "^0.26.0",
         "wawoff2": "^2.0.1"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
+        "@types/pdfkit": "^0.17.6",
         "bootstrap": "^5.3.8",
         "purgecss": "^8.0.0",
         "typescript": "^6.0.3"
@@ -1274,6 +1276,30 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
@@ -2020,6 +2046,15 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2075,6 +2110,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/pdfkit": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.17.6.tgz",
+      "integrity": "sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/sax": {
@@ -2462,6 +2507,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/brotli/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/browserify-zlib/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/camelize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
@@ -2554,6 +2643,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {
@@ -2849,6 +2947,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -3076,7 +3180,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3237,6 +3340,23 @@
       "license": "MIT",
       "dependencies": {
         "fontkitten": "^1.0.2"
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/fontkitten": {
@@ -3663,6 +3783,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -4845,6 +4971,20 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/pdfkit": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.19.1.tgz",
+      "integrity": "sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.1.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -4867,6 +5007,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -5209,6 +5357,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/retext": {
       "version": "9.0.0",
@@ -5696,8 +5850,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",
@@ -5752,6 +5905,36 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-properties/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/unicode-trie": {

--- a/blog-src/package.json
+++ b/blog-src/package.json
@@ -17,11 +17,13 @@
     "@astrojs/sitemap": "^3.7.3",
     "@resvg/resvg-js": "^2.6.2",
     "astro": "^6.4.4",
+    "pdfkit": "^0.19.1",
     "satori": "^0.26.0",
     "wawoff2": "^2.0.1"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@types/pdfkit": "^0.17.6",
     "bootstrap": "^5.3.8",
     "purgecss": "^8.0.0",
     "typescript": "^6.0.3"

--- a/blog-src/public/_headers
+++ b/blog-src/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://laplantedevanalytics.netlify.app https://static.cloudflareinsights.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://laplantedevanalytics.netlify.app; frame-src https://challenges.cloudflare.com; form-action 'self' https://buttondown.com; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://laplantedevanalytics.netlify.app https://static.cloudflareinsights.com https://challenges.cloudflare.com https://app.cal.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://laplantedevanalytics.netlify.app https://app.cal.com; frame-src https://challenges.cloudflare.com https://app.cal.com; form-action 'self' https://buttondown.com; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; upgrade-insecure-requests
   Cache-Control: public, max-age=0, must-revalidate
   CDN-Cache-Control: public, max-age=3600, stale-while-revalidate=86400
 

--- a/blog-src/public/js/cal-embed.js
+++ b/blog-src/public/js/cal-embed.js
@@ -1,0 +1,67 @@
+/* Cal.com inline embed bootstrap for the booking section on /services.
+   External file (rather than an inline <script>) so the site CSP can serve
+   script-src without 'unsafe-inline'; app.cal.com is the only third-party
+   origin involved and is allowlisted in public/_headers. */
+(function () {
+	'use strict';
+
+	var mount = document.getElementById('cal-booking');
+	if (!mount) return;
+	var calLink = mount.getAttribute('data-cal-link');
+	if (!calLink) return;
+
+	/* Official Cal.com embed loader snippet (queues calls until embed.js loads). */
+	(function (C, A, L) {
+		var p = function (a, ar) { a.q.push(ar); };
+		var d = C.document;
+		C.Cal = C.Cal || function () {
+			var cal = C.Cal;
+			var ar = arguments;
+			if (!cal.loaded) {
+				cal.ns = {};
+				cal.q = cal.q || [];
+				d.head.appendChild(d.createElement('script')).src = A;
+				cal.loaded = true;
+			}
+			if (ar[0] === L) {
+				var api = function () { p(api, arguments); };
+				var namespace = ar[1];
+				api.q = api.q || [];
+				if (typeof namespace === 'string') {
+					cal.ns[namespace] = cal.ns[namespace] || api;
+					p(cal.ns[namespace], ar);
+					p(cal, ['initNamespace', namespace]);
+				} else {
+					p(cal, ar);
+				}
+				return;
+			}
+			p(cal, ar);
+		};
+	})(window, 'https://app.cal.com/embed/embed.js', 'init');
+
+	/* Match the site's dark mode (same logic as script.js: explicit localStorage
+	   choice wins, otherwise follow the OS preference). */
+	var dark = false;
+	try {
+		var stored = localStorage.getItem('darkMode');
+		dark = stored === 'enabled' ||
+			(stored !== 'disabled' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+	} catch (e) {
+		/* localStorage unavailable — keep the light theme */
+	}
+
+	window.Cal('init', { origin: 'https://app.cal.com' });
+	window.Cal('inline', {
+		elementOrSelector: '#cal-booking',
+		calLink: calLink,
+		config: { theme: dark ? 'dark' : 'light' },
+	});
+	window.Cal('ui', {
+		hideEventTypeDetails: false,
+		cssVarsPerTheme: {
+			light: { 'cal-brand': '#1a5276' },
+			dark: { 'cal-brand': '#60a5fa' },
+		},
+	});
+})();

--- a/blog-src/src/config.ts
+++ b/blog-src/src/config.ts
@@ -9,3 +9,8 @@ export const AUTHOR_NAME = 'Michael LaPlante';
 // autodiscovery links so the title/description can't drift between them.
 export const BLOG_TITLE = "Michael LaPlante's Blog";
 export const BLOG_DESCRIPTION = 'Thoughts on security, engineering, and building things.';
+
+// Cal.com booking handle for the inline scheduler on /services — either a
+// plain username ('mlaplante') or 'username/event-type' for a specific event.
+// Set to '' to hide every piece of booking UI until an account exists.
+export const CAL_LINK = 'mlaplante';

--- a/blog-src/src/pages/index.astro
+++ b/blog-src/src/pages/index.astro
@@ -4,6 +4,7 @@ import { getReadTime } from '../utils/readTime';
 import { formatDateShort } from '../utils/format';
 import { getSortedPosts } from '../utils/posts';
 import { profile, summary, stats, skills, experience, certifications } from '../data/resume';
+import { CAL_LINK } from '../config';
 
 const posts = (await getSortedPosts()).slice(0, 4);
 ---
@@ -384,6 +385,12 @@ const posts = (await getSortedPosts()).slice(0, 4);
         <h2>Contact Me</h2>
       </div>
 
+      {CAL_LINK && (
+        <p class="contact-booking-note" data-aos="fade-up">
+          Want to skip the back-and-forth? <a href="/services/#book">Book a call directly</a>.
+        </p>
+      )}
+
       <form name="contact" method="POST" action="/api/contact" class="contact-form" data-aos="fade-up">
         <p class="hidden" style="display:none" aria-hidden="true">
           <label>Don't fill this out: <input name="bot-field" tabindex="-1" autocomplete="off"></label>
@@ -487,4 +494,19 @@ const posts = (await getSortedPosts()).slice(0, 4);
   :global(body.dark-mode) .post-preview h4 { color: #f1f5f9; }
   :global(body.dark-mode) .post-preview p { color: #94a3b8; }
   :global(body.dark-mode) .post-preview-date { color: #64748b; }
+
+  .contact-booking-note {
+    margin: -10px 0 24px;
+    font-size: 15px;
+  }
+  .contact-booking-note a {
+    color: #2980b9;
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .contact-booking-note a:hover { opacity: 0.7; }
+  @media (prefers-color-scheme: dark) {
+    .contact-booking-note a { color: #60a5fa; }
+  }
+  :global(body.dark-mode) .contact-booking-note a { color: #60a5fa; }
 </style>

--- a/blog-src/src/pages/resume.astro
+++ b/blog-src/src/pages/resume.astro
@@ -52,7 +52,10 @@ import { profile, summary, stats, skills, experience, certifications } from '../
   <main id="main-content" class="resume-page">
     <div class="resume-toolbar">
       <a href="/" class="resume-back">&larr; Back to site</a>
-      <button type="button" id="resume-print" class="resume-print-btn">Download PDF</button>
+      <div class="resume-toolbar-actions">
+        <button type="button" id="resume-print" class="resume-print-btn resume-btn-ghost">Print</button>
+        <a href="/resume.pdf" download="Michael-LaPlante-Resume.pdf" class="resume-print-btn">Download PDF</a>
+      </div>
     </div>
 
     <article class="resume-paper">
@@ -167,6 +170,11 @@ import { profile, summary, stats, skills, experience, certifications } from '../
   }
   .resume-back:hover { opacity: 0.7; }
 
+  .resume-toolbar-actions {
+    display: flex;
+    gap: 10px;
+  }
+
   .resume-print-btn {
     font-family: 'Poppins', sans-serif;
     font-size: 14px;
@@ -178,8 +186,20 @@ import { profile, summary, stats, skills, experience, certifications } from '../
     color: #fff;
     cursor: pointer;
     transition: background 0.2s;
+    text-decoration: none;
+    display: inline-block;
   }
-  .resume-print-btn:hover { background: #1a6da3; }
+  .resume-print-btn:hover { background: #1a6da3; color: #fff; }
+
+  .resume-btn-ghost {
+    background: transparent;
+    color: #2980b9;
+    box-shadow: inset 0 0 0 2px #2980b9;
+  }
+  .resume-btn-ghost:hover {
+    background: rgba(41, 128, 185, 0.1);
+    color: #2980b9;
+  }
 
   /* The résumé "paper" — kept light in both color schemes so it reads like a
      printed document and the on-screen view matches the PDF. */

--- a/blog-src/src/pages/resume.pdf.ts
+++ b/blog-src/src/pages/resume.pdf.ts
@@ -1,0 +1,14 @@
+import type { APIRoute } from 'astro';
+import { renderResumePdf } from '../utils/resumePdf';
+
+// Prerendered at build time into dist/resume.pdf — the downloadable twin of
+// the /resume page, generated from the same src/data/resume.ts module.
+export const GET: APIRoute = async () => {
+  const pdf = await renderResumePdf();
+  return new Response(new Uint8Array(pdf), {
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': 'inline; filename="Michael-LaPlante-Resume.pdf"',
+    },
+  });
+};

--- a/blog-src/src/pages/services.astro
+++ b/blog-src/src/pages/services.astro
@@ -1,7 +1,9 @@
 ---
 import SiteLayout from '../layouts/SiteLayout.astro';
 import { stats } from '../data/resume';
-import { SITE_URL } from '../config';
+import { SITE_URL, CAL_LINK } from '../config';
+
+const bookingUrl = CAL_LINK ? `https://cal.com/${CAL_LINK}` : '';
 
 const services = [
   {
@@ -83,6 +85,15 @@ const professionalServiceSchema = JSON.stringify({
     "https://github.com/mlaplante",
     "https://twitter.com/laplantewebdev",
   ],
+  ...(bookingUrl
+    ? {
+        potentialAction: {
+          "@type": "ReserveAction",
+          name: "Book a consultation call",
+          target: bookingUrl,
+        },
+      }
+    : {}),
 });
 ---
 
@@ -152,7 +163,9 @@ const professionalServiceSchema = JSON.stringify({
         one-size-fits-all checklist.
       </p>
       <div data-aos="fade-up" style="margin-top: 20px;">
-        <a href="/#contact" class="btn btn-custom">Schedule a Consultation</a>
+        {bookingUrl
+          ? <a href="#book" data-scroll class="btn btn-custom">Book a Call</a>
+          : <a href="/#contact" class="btn btn-custom">Schedule a Consultation</a>}
       </div>
     </div>
   </section>
@@ -216,6 +229,27 @@ const professionalServiceSchema = JSON.stringify({
     </div>
   </section>
 
+  <!-- Booking -->
+  {bookingUrl && (
+    <section class="section" id="book">
+      <div class="container">
+        <div class="section-header" data-aos="fade-up">
+          <h2>Book a Call</h2>
+        </div>
+        <p data-aos="fade-up">
+          Grab a time that works for you — a free intro call to talk through
+          your security challenge and see whether we're a fit. No prep needed.
+        </p>
+        <div id="cal-booking" data-cal-link={CAL_LINK} data-aos="fade-up"></div>
+        <p class="booking-fallback" data-aos="fade-up">
+          Calendar not loading?
+          <a href={bookingUrl} rel="noopener">Open the booking page directly</a>
+          or use the <a href="/#contact">contact form</a>.
+        </p>
+      </div>
+    </section>
+  )}
+
   <!-- CTA -->
   <section class="section" id="services-cta">
     <div class="container">
@@ -227,7 +261,8 @@ const professionalServiceSchema = JSON.stringify({
         up? Tell me what you're working on and I'll get back to you.
       </p>
       <div data-aos="fade-up" style="margin-top: 20px;">
-        <a href="/#contact" class="btn btn-custom">Get In Touch</a>
+        {bookingUrl && <a href="#book" data-scroll class="btn btn-custom">Book a Call</a>}
+        <a href="/#contact" class={`btn btn-custom${bookingUrl ? ' btn-ghost' : ''}`}>Get In Touch</a>
       </div>
     </div>
   </section>
@@ -250,9 +285,21 @@ const professionalServiceSchema = JSON.stringify({
     JavaScript Files
   =========================================-->
   <script is:inline src="/js/script.js"></script>
+  {bookingUrl && <script is:inline defer src="/js/cal-embed.js"></script>}
 </SiteLayout>
 
 <style>
+  /* Reserve space so the page doesn't jump while the Cal.com embed loads. */
+  #cal-booking {
+    min-height: 560px;
+    margin-top: 10px;
+  }
+
+  .booking-fallback {
+    font-size: 14px;
+    margin-top: 14px;
+  }
+
   .process-step {
     display: inline-block;
     font-family: 'Roboto Mono', monospace;

--- a/blog-src/src/utils/resumePdf.ts
+++ b/blog-src/src/utils/resumePdf.ts
@@ -1,0 +1,196 @@
+// Renders the downloadable /resume.pdf at build time from the same
+// src/data/resume.ts module that powers the homepage and the /resume page —
+// the PDF can never drift from the on-site résumé. pdfkit draws the document
+// directly (no headless browser), so it runs anywhere the Astro build runs.
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import PDFDocument from 'pdfkit';
+import { decompress } from 'wawoff2';
+import { profile, summary, stats, skills, experience, certifications } from '../data/resume';
+
+// Walk up to the project's public/ dir instead of using a fixed relative
+// path: Astro's prerender step rebundles this module into
+// .astro/.prerender/chunks/, so import.meta.url's depth differs between the
+// source tree (vitest) and the build.
+function findPublicDir(start: string): string {
+  let dir = start;
+  while (true) {
+    if (existsSync(resolve(dir, 'public/fonts/poppins'))) return resolve(dir, 'public');
+    const parent = dirname(dir);
+    if (parent === dir) throw new Error('Could not locate public/fonts/poppins above ' + start);
+    dir = parent;
+  }
+}
+
+const PUBLIC = findPublicDir(dirname(fileURLToPath(import.meta.url)));
+
+// Brand palette, mirroring the .resume-* styles on /resume.
+const NAVY = '#1a5276';
+const HEADING = '#111827';
+const BODY = '#374151';
+const MUTED = '#6b7280';
+const RULE = '#e5e7eb';
+
+// pdfkit needs TTF; the site ships WOFF2, so decompress at build time the
+// same way the OG image generator does (see pages/og/[slug].png.ts, including
+// the fresh-Buffer copy that keeps the WASM-owned bytes stable).
+function freshBuffer(u8: Uint8Array): Buffer {
+  const buf = Buffer.alloc(u8.length);
+  buf.set(u8);
+  return buf;
+}
+
+let fontCache: { regular: Buffer; semibold: Buffer; bold: Buffer } | null = null;
+
+// Decompress strictly one at a time, copying each result before starting the
+// next: wawoff2's WASM memory can grow (detaching earlier views) when calls
+// overlap, which surfaces as fontkit "Unknown font format" errors.
+async function loadFonts() {
+  if (fontCache) return fontCache;
+  const ttf = async (weight: string) =>
+    freshBuffer(await decompress(readFileSync(`${PUBLIC}/fonts/poppins/poppins-${weight}.woff2`)));
+  fontCache = {
+    regular: await ttf('400'),
+    semibold: await ttf('600'),
+    bold: await ttf('700'),
+  };
+  return fontCache;
+}
+
+export async function renderResumePdf(): Promise<Buffer> {
+  const fonts = await loadFonts();
+
+  const doc = new PDFDocument({
+    size: 'LETTER',
+    margins: { top: 54, bottom: 54, left: 58, right: 58 },
+    info: {
+      Title: `${profile.name} — Résumé`,
+      Author: profile.name,
+      Subject: profile.title,
+    },
+  });
+  doc.registerFont('body', fonts.regular);
+  doc.registerFont('semibold', fonts.semibold);
+  doc.registerFont('bold', fonts.bold);
+
+  const chunks: Buffer[] = [];
+  doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+  const finished = new Promise<Buffer>((resolvePdf) => {
+    doc.on('end', () => resolvePdf(Buffer.concat(chunks)));
+  });
+
+  const left = doc.page.margins.left;
+  const contentWidth = doc.page.width - left - doc.page.margins.right;
+  const bottom = () => doc.page.height - doc.page.margins.bottom;
+
+  // Start a new page early rather than splitting a heading or a job header
+  // from the content beneath it.
+  const ensureSpace = (needed: number) => {
+    if (doc.y + needed > bottom()) doc.addPage();
+  };
+
+  const sectionHeading = (title: string) => {
+    ensureSpace(70);
+    doc
+      .font('bold')
+      .fontSize(10)
+      .fillColor(NAVY)
+      .text(title.toUpperCase(), left, doc.y, { characterSpacing: 1.5 });
+    const y = doc.y + 4;
+    doc.moveTo(left, y).lineTo(left + contentWidth, y).lineWidth(0.7).strokeColor(RULE).stroke();
+    doc.y = y + 10;
+  };
+
+  // ── Header ────────────────────────────────────────────────────────────
+  doc.font('bold').fontSize(24).fillColor(HEADING).text(profile.name, left, doc.y);
+  doc.moveDown(0.15);
+  doc.font('semibold').fontSize(11).fillColor(NAVY).text(profile.title, { characterSpacing: 0.3 });
+  doc.moveDown(0.4);
+
+  const linkedin = profile.links.find((l) => l.label === 'LinkedIn');
+  const contactParts = [profile.email, profile.website, ...(linkedin ? [linkedin.url] : [])];
+  doc.font('body').fontSize(9).fillColor(MUTED).text(contactParts.join('   ·   '));
+
+  const ruleY = doc.y + 10;
+  doc.moveTo(left, ruleY).lineTo(left + contentWidth, ruleY).lineWidth(1.4).strokeColor(NAVY).stroke();
+  doc.y = ruleY + 18;
+
+  // ── Summary ───────────────────────────────────────────────────────────
+  sectionHeading('Summary');
+  for (const para of summary) {
+    doc.font('body').fontSize(9.5).fillColor(BODY).text(para, { lineGap: 2.4 });
+    doc.moveDown(0.5);
+  }
+  doc.moveDown(0.4);
+
+  // ── Highlights ────────────────────────────────────────────────────────
+  sectionHeading('Highlights');
+  stats.forEach((stat, i) => {
+    const last = i === stats.length - 1;
+    doc.font('semibold').fontSize(10).fillColor(NAVY).text(`${stat.value} `, { continued: true });
+    doc
+      .font('body')
+      .fillColor(MUTED)
+      .text(`${stat.label}${last ? '' : '    ·    '}`, { continued: !last });
+  });
+  doc.moveDown(0.9);
+
+  // ── Areas of Expertise ────────────────────────────────────────────────
+  sectionHeading('Areas of Expertise');
+  for (const skill of skills) {
+    ensureSpace(26);
+    doc
+      .font('semibold')
+      .fontSize(9.5)
+      .fillColor(HEADING)
+      .text(`${skill.name}  `, { continued: true, lineGap: 1.6 });
+    doc.font('body').fillColor(MUTED).text(`— ${skill.description}`);
+    doc.moveDown(0.25);
+  }
+  doc.moveDown(0.65);
+
+  // ── Certifications (only when actually held — see data/resume.ts) ────
+  if (certifications.length > 0) {
+    sectionHeading('Certifications');
+    for (const cert of certifications) {
+      ensureSpace(20);
+      doc.font('semibold').fontSize(9.5).fillColor(HEADING).text(cert.name, { continued: true });
+      doc
+        .font('body')
+        .fillColor(MUTED)
+        .text(`  ·  ${cert.issuer}${cert.year ? `  ·  ${cert.year}` : ''}`);
+      doc.moveDown(0.25);
+    }
+    doc.moveDown(0.65);
+  }
+
+  // ── Experience ────────────────────────────────────────────────────────
+  sectionHeading('Experience');
+  for (const job of experience) {
+    ensureSpace(56);
+    const headY = doc.y;
+    doc.font('body').fontSize(8.5);
+    const dateWidth = doc.widthOfString(job.date) + 4;
+    doc.fillColor(MUTED).text(job.date, left, headY + 1.5, { width: contentWidth, align: 'right' });
+
+    doc.y = headY;
+    doc
+      .font('semibold')
+      .fontSize(10.5)
+      .fillColor(HEADING)
+      .text(job.role, left, headY, { width: contentWidth - dateWidth - 10, continued: true });
+    doc.font('body').fillColor(NAVY).text(`  ·  ${job.company}`);
+
+    doc.moveDown(0.2);
+    doc
+      .font('body')
+      .fontSize(9)
+      .fillColor(BODY)
+      .text(job.description, left, doc.y, { width: contentWidth, lineGap: 1.8 });
+    doc.moveDown(0.75);
+  }
+
+  doc.end();
+  return finished;
+}

--- a/tests/lib/resume-pdf.test.js
+++ b/tests/lib/resume-pdf.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+
+import { renderResumePdf } from '../../blog-src/src/utils/resumePdf.ts';
+import { profile, experience } from '../../blog-src/src/data/resume.ts';
+
+describe('renderResumePdf', () => {
+  it('produces a structurally valid PDF', async () => {
+    const pdf = await renderResumePdf();
+
+    expect(pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+    expect(pdf.subarray(-32).toString('latin1')).toContain('%%EOF');
+    // Embedded fonts alone are tens of KB — a tiny file means rendering bailed.
+    expect(pdf.length).toBeGreaterThan(20_000);
+  });
+
+  it('carries the résumé data in the document', async () => {
+    const pdf = await renderResumePdf();
+    const raw = pdf.toString('latin1');
+
+    // Page streams are deflate-compressed, but the Info dictionary is not —
+    // it proves the document was built from the shared resume.ts module.
+    expect(raw).toContain(profile.name);
+    expect(raw).toContain(profile.title);
+
+    // One content stream per page; the full work history needs > 1 page.
+    const pages = raw.match(/\/Type\s*\/Page[^s]/g) ?? [];
+    expect(pages.length).toBeGreaterThanOrEqual(2);
+    expect(experience.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Book a Call: inline Cal.com scheduler on /services (new #book section),
bootstrapped by an external script so the strict CSP stays free of
'unsafe-inline'; app.cal.com allowlisted in script-src/connect-src/
frame-src. Embed theme follows the site's dark mode, with link-out and
contact-form fallbacks, a homepage pointer above the contact form, and a
ReserveAction in the ProfessionalService JSON-LD. The handle lives in
CAL_LINK (src/config.ts); setting it to '' hides all booking UI.

Resume PDF: /resume.pdf is prerendered at build time by pdfkit from the
same src/data/resume.ts module that powers the homepage and /resume, so
the download can't drift from the site. Uses the site's own Poppins
WOFF2 fonts (decompressed sequentially — overlapping wawoff2 calls
detach earlier WASM views). /resume now offers Download PDF alongside
the existing print button. Covered by a new lib test.

https://claude.ai/code/session_019LUt7b9XfCtssa12uRp4EY