### PR TITLE
Group all npm dependency updates, including majors, into one Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,18 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     groups:
-      # All bumps (patch/minor/major) land as one PR so every package is
-      # kept at its latest version with minimal review noise.
-      all-updates:
+      # Patch/minor bumps land as one PR to cut review noise; majors are
+      # grouped into their own PR so breaking changes stay visible.
+      minor-and-patch:
         patterns:
           - "*"
         update-types:
           - minor
           - patch
+      majors:
+        patterns:
+          - "*"
+        update-types:
           - major
 
   # Astro site package.
@@ -29,12 +33,16 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     groups:
-      all-updates:
+      minor-and-patch:
         patterns:
           - "*"
         update-types:
           - minor
           - patch
+      majors:
+        patterns:
+          - "*"
+        update-types:
           - major
 
   # Workflow actions (pinned to commit SHAs).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,15 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     groups:
-      # Patch/minor bumps land as one PR to cut review noise; majors stay
-      # separate so breaking changes get individual attention.
-      minor-and-patch:
+      # All bumps (patch/minor/major) land as one PR so every package is
+      # kept at its latest version with minimal review noise.
+      all-updates:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch
+          - major
 
   # Astro site package.
   - package-ecosystem: npm
@@ -26,10 +29,13 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     groups:
-      minor-and-patch:
+      all-updates:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch
+          - major
 
   # Workflow actions (pinned to commit SHAs).
   - package-ecosystem: github-actions


### PR DESCRIPTION
Previously major version bumps were excluded from the minor-and-patch
group and opened as individual PRs. Now every update type is grouped so
all packages are kept at their latest versions in a single weekly PR
per package root.

https://claude.ai/code/session_01TyXUydCEoM1o5hXBxrpUB3