### PR TITLE
Add CI, security scanning, and content-quality GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+# A newer push to the same branch/PR supersedes any in-flight run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Worker + lib tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Actions are pinned to full commit SHAs so a moved/compromised tag
+      # can't inject code into the workflow.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Worker integration tests (real Workers runtime + Miniflare D1) and
+      # shared-lib unit tests.
+      - name: Run tests
+        run: npm test
+
+  site:
+    name: Astro typecheck + build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: blog-src/package-lock.json
+
+      - name: Install site dependencies
+        run: npm ci
+        working-directory: blog-src
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # Full production build: validates content-collection frontmatter for
+      # every post/draft (including AI-generated drafts), renders OG images,
+      # and runs the PurgeCSS pass.
+      - name: Build site
+        run: npm run build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly re-scan so new CodeQL queries run against unchanged code.
+    - cron: '30 7 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write  # upload SARIF results to the Security tab
+      actions: read
+    steps:
+      # Pinned to a full commit SHA so a moved/compromised tag can't inject
+      # code into the workflow.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+name: Dependabot Auto-Merge
+
+# Flags Dependabot's grouped minor/patch PRs for auto-merge. GitHub only
+# completes the merge once every required check on the PR passes, so this
+# relies on branch protection requiring the CI workflow (and "Allow
+# auto-merge" being enabled in the repository settings). Major-version PRs
+# are left for human review.
+
+on: pull_request
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    # `user.login` (not `github.actor`) so a human re-triggering the workflow
+    # on a Dependabot PR can't be confused for Dependabot itself.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'mlaplante/resumesite'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        # Pinned to a full commit SHA so a moved/compromised tag can't inject
+        # code into a workflow that holds `contents: write`.
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor/patch updates
+        # For grouped PRs, `update-type` reports the highest bump in the
+        # group, so a group containing any major update is skipped.
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,34 @@
+name: Secret Scan
+
+# Enforced counterpart to githooks/pre-commit, which only runs when a
+# contributor has installed both the hook and the gitleaks binary.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # gitleaks-action comments on the PR when it detects a leak.
+      pull-requests: write
+    steps:
+      # Pinned to a full commit SHA so a moved/compromised tag can't inject
+      # code into the workflow.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0  # scan the full commit history, not just HEAD
+          persist-credentials: false
+
+      # No GITLEAKS_LICENSE needed: only required for organization-owned repos.
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,58 @@
+name: Link Check
+
+# Blog posts accumulate dead external links over time (and an AI draft
+# generator occasionally invents one). Check weekly and file an issue with
+# the report rather than failing a PR over someone else's outage.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      # Pinned to a full commit SHA so a moved/compromised tag can't inject
+      # code into the workflow.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Check links in blog content
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          # http(s) only: relative links resolve to site routes, not files on
+          # disk, so checking them here would only produce false positives.
+          # 429 is accepted — rate-limited is not broken. LinkedIn and X
+          # block bots outright, so they can't be checked meaningfully.
+          args: >-
+            --no-progress
+            --scheme https --scheme http
+            --accept '100..=103,200..=299,429'
+            --exclude 'linkedin\.com'
+            --exclude '(twitter|x)\.com'
+            'blog-src/src/content/**/*.md'
+            README.md
+          output: lychee-report.md
+          fail: true
+
+      - name: File or update the broken-links issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Link check: broken links in blog content"
+          existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file lychee-report.md
+          else
+            gh issue create --title "$title" --body-file lychee-report.md
+          fi

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,56 @@
+name: Lint Workflows
+
+# actionlint catches expression/shellcheck bugs in workflow YAML; zizmor
+# audits for security smells (template injection, excessive permissions,
+# spoofable bot checks). Dependabot keeps the pinned versions current.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Pinned to a full commit SHA so a moved/compromised tag can't inject
+      # code into the workflow.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # actionlint ships no official action; download the release binary and
+      # verify its checksum instead of piping a remote script into bash.
+      - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          curl -sSLo actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar xzf actionlint.tar.gz actionlint
+          ./actionlint -color
+
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write  # upload findings to the Security tab
+      actions: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          version: 1.25.2

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,25 @@
+name: Spell Check
+
+# Catches typos in AI-generated drafts (and everything else) before they're
+# published. Dictionary exceptions live in _typos.toml at the repo root.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Pinned to a full commit SHA so a moved/compromised tag can't inject
+      # code into the workflow.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+# zizmor configuration — see .github/workflows/lint-workflows.yml.
+
+rules:
+  # These two workflows push commits/branches back to the repo, so the
+  # checkout step must keep its credentials. Every other workflow sets
+  # `persist-credentials: false`.
+  artipacked:
+    ignore:
+      - generate-blog-post.yml
+      - publish-blog-post.yml

--- a/README.md
+++ b/README.md
@@ -83,9 +83,16 @@ resumesite/
 ├── wrangler.jsonc                  # Cloudflare Worker config (D1 binding, assets)
 ├── package.json                    # Root npm scripts (delegates to blog-src/)
 └── .github/workflows/
+    ├── ci.yml                      # Tests, typecheck, full Astro build
+    ├── codeql.yml                  # CodeQL static analysis
+    ├── dependabot-auto-merge.yml   # Auto-merge minor/patch dependency PRs
     ├── generate-blog-post.yml      # AI draft generation
+    ├── gitleaks.yml                # Secret scanning
+    ├── link-check.yml              # Weekly dead-link sweep of blog content
+    ├── lint-workflows.yml          # actionlint + zizmor on workflow YAML
     ├── publish-blog-post.yml       # Draft-to-post promotion
-    └── purge-cloudflare-cache.yml  # CDN cache invalidation
+    ├── purge-cloudflare-cache.yml  # CDN cache invalidation
+    └── typos.yml                   # Spell check (config: _typos.toml)
 ```
 
 ## Getting Started
@@ -239,9 +246,18 @@ The site deploys to **Cloudflare** as a Worker plus static assets:
 
 | Workflow                       | Trigger              | Purpose |
 |--------------------------------|----------------------|---------|
+| `ci.yml`                       | PRs / push to master | Worker + lib tests, Astro typecheck, full production build |
+| `codeql.yml`                   | PRs / push / weekly  | CodeQL static analysis of the Worker and scripts |
+| `dependabot-auto-merge.yml`    | Dependabot PRs       | Flag minor/patch dependency PRs for auto-merge |
 | `generate-blog-post.yml`       | Manual / scheduled   | Generate AI blog drafts via Gemini (opens a PR) |
+| `gitleaks.yml`                 | PRs / push to master | Secret scanning over the full git history |
+| `link-check.yml`               | Weekly / manual      | Dead-link sweep of blog content; files an issue with the report |
+| `lint-workflows.yml`           | Workflow changes     | actionlint + zizmor security audit of workflow YAML |
 | `publish-blog-post.yml`        | PR merge (label-gated) | Move drafts → posts on merge |
 | `purge-cloudflare-cache.yml`   | Post-push to master  | Invalidate Cloudflare CDN cache |
+| `typos.yml`                    | PRs / push to master | Spell check; exceptions live in `_typos.toml` |
+
+`dependabot-auto-merge.yml` only *flags* a PR — GitHub completes the merge once every required check passes. Enable **Allow auto-merge** in the repository settings and add branch protection on `master` requiring the CI checks, or the merge will happen without waiting for them.
 
 ### Custom Domain
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,18 @@
+# Spell-check configuration for crate-ci/typos, run in CI by
+# .github/workflows/typos.yml.
+
+[files]
+extend-exclude = [
+  "package-lock.json",
+  "blog-src/package-lock.json",
+]
+
+[default.extend-words]
+# Brand names, acronyms, and accepted variants the default dictionary flags.
+aks = "aks"                  # Azure Kubernetes Service
+counterfit = "counterfit"    # Microsoft Counterfit (AI security tool)
+hashi = "hashi"              # HashiCorp
+hav = "hav"                  # hardware-assisted virtualization
+shure = "shure"              # Shure SM7B microphone
+sie = "sie"                  # SIEM/SIEMs tokenizes as SIE + Ms
+unparseable = "unparseable"  # valid variant of "unparsable"

--- a/blog-src/src/content/posts/2026-03-28-securing-ai-powered-workflows-practical-strategies-for-integrating-llms-into-enterprise-devsecops-pipelines.md
+++ b/blog-src/src/content/posts/2026-03-28-securing-ai-powered-workflows-practical-strategies-for-integrating-llms-into-enterprise-devsecops-pipelines.md
@@ -3,7 +3,7 @@ title: "Securing AI-Powered Workflows: Practical Strategies for Integrating LLMs
 date: 2026-03-28
 category: "thought-leadership"
 tags: []
-excerpt: "It’s no secret that AI-driven tools like Large Language Models (LLMs) are reshaping enterprise workflows. From automated code reviews to advanced thre..."
+excerpt: "It’s no secret that AI-driven tools like Large Language Models (LLMs) are reshaping enterprise workflows. From automated code reviews to advanced..."
 ---
 
 # Securing AI-Powered Workflows: Practical Strategies for Integrating LLMs into Enterprise DevSecOps Pipelines

--- a/blog-src/src/content/posts/2026-04-03-leveraging-ai-powered-threat-detection-to-secure-multi-cloud-environments.md
+++ b/blog-src/src/content/posts/2026-04-03-leveraging-ai-powered-threat-detection-to-secure-multi-cloud-environments.md
@@ -3,7 +3,7 @@ title: "Leveraging AI-Powered Threat Detection to Secure Multi-Cloud Environment
 date: 2026-04-03
 category: "thought-leadership"
 tags: []
-excerpt: "Multi-cloud environments are here to stay. Organizations are embracing the agility and resilience of using multiple cloud providers, but with that fle..."
+excerpt: "Multi-cloud environments are here to stay. Organizations are embracing the agility and resilience of using multiple cloud providers, but with that..."
 ---
 
 # Leveraging AI-Powered Threat Detection to Secure Multi-Cloud Environments

--- a/blog-src/src/content/posts/2026-04-18-implementing-zero-trust-network-segmentation-with-ebpf-a-hands-on-guide.md
+++ b/blog-src/src/content/posts/2026-04-18-implementing-zero-trust-network-segmentation-with-ebpf-a-hands-on-guide.md
@@ -3,7 +3,7 @@ title: "Implementing Zero Trust Network Segmentation with eBPF: A Hands-On Guide
 date: 2026-04-18
 category: "thought-leadership"
 tags: []
-excerpt: "Zero Trust is more than a buzzword—it's a mandate for modern security. As network boundaries blur and attack surfaces expand, traditional perimeter-ba..."
+excerpt: "Zero Trust is more than a buzzword—it's a mandate for modern security. As network boundaries blur and attack surfaces expand, traditional..."
 ---
 
 # Implementing Zero Trust Network Segmentation with eBPF: A Hands-On Guide

--- a/blog-src/src/content/posts/2026-04-20-automating-zero-downtime-database-migrations-with-gitops-and-kubernetes.md
+++ b/blog-src/src/content/posts/2026-04-20-automating-zero-downtime-database-migrations-with-gitops-and-kubernetes.md
@@ -3,7 +3,7 @@ title: "Automating Zero-Downtime Database Migrations with GitOps and Kubernetes"
 date: 2026-04-20
 category: "thought-leadership"
 tags: []
-excerpt: "Database migrations are a critical—but often nerve-wracking—part of deploying modern applications. Nothing kills momentum like a botched migration tha..."
+excerpt: "Database migrations are a critical—but often nerve-wracking—part of deploying modern applications. Nothing kills momentum like a botched migration..."
 ---
 
 # Automating Zero-Downtime Database Migrations with GitOps and Kubernetes

--- a/blog-src/src/content/posts/2026-05-04-building-resilient-systems-immutable-infrastructure-with-nixos-and-hashicorp-nomad.md
+++ b/blog-src/src/content/posts/2026-05-04-building-resilient-systems-immutable-infrastructure-with-nixos-and-hashicorp-nomad.md
@@ -3,7 +3,7 @@ title: "Building Resilient Systems: Immutable Infrastructure with NixOS and Hash
 date: 2026-05-04
 category: "thought-leadership"
 tags: []
-excerpt: "In the world of modern infrastructure, the pursuit of reliability, predictability, and efficiency is constant. One paradigm that has gained significan..."
+excerpt: "In the world of modern infrastructure, the pursuit of reliability, predictability, and efficiency is constant. One paradigm that has gained..."
 ---
 
 # Building Resilient Systems: Immutable Infrastructure with NixOS and HashiCorp Nomad

--- a/blog-src/src/content/posts/2026-05-06-automating-cloud-security-policy-enforcement-with-opa-and-gitops.md
+++ b/blog-src/src/content/posts/2026-05-06-automating-cloud-security-policy-enforcement-with-opa-and-gitops.md
@@ -169,7 +169,7 @@ Here's how we can integrate them:
 1.  **Start Small with Critical Policies:** Don't try to automate everything at once. Identify your top 3-5 critical security policies (e.g., S3 encryption, public access for databases, allowed instance types) and implement OPA for those first.
 2.  **Define Your Policy Input Schema:** Understand the structure of the data OPA will evaluate (Terraform plan JSON, CloudFormation template, Kubernetes manifest). This helps in writing precise Rego policies.
 3.  **Integrate Early in the Lifecycle:** The earlier you catch policy violations, the cheaper they are to fix. Prioritize pre-commit hooks and CI/CD pipeline integration.
-4.  **Leverage OPA Tooling:** Explore `conftest` (for IaC policy validation), OPA Gatekeeper (for Kubernetes admission control), and the OPA Playgorund for testing Rego policies.
+4.  **Leverage OPA Tooling:** Explore `conftest` (for IaC policy validation), OPA Gatekeeper (for Kubernetes admission control), and the OPA Playground for testing Rego policies.
 5.  **Educate Your Teams:** Policy-as-code is a cultural shift. Educate your development and operations teams on how OPA works, how to write compliant code, and how to interpret OPA feedback.
 6.  **Version Control Your Policies:** Treat your Rego policies like any other codebase. Store them in Git, review them via pull requests, and version them. This is the "Git" part of your policy enforcement GitOps.
 

--- a/blog-src/src/content/posts/2026-05-16-templates-k8srequiredlabels-yaml.md
+++ b/blog-src/src/content/posts/2026-05-16-templates-k8srequiredlabels-yaml.md
@@ -3,7 +3,7 @@ title: "templates/k8srequiredlabels.yaml"
 date: 2026-05-16
 category: "thought-leadership"
 tags: []
-excerpt: "In the dynamic world of Kubernetes, ensuring security, compliance, and operational best practices isn't just a good idea – it's a necessity. As cluste..."
+excerpt: "In the dynamic world of Kubernetes, ensuring security, compliance, and operational best practices isn't just a good idea – it's a necessity. As..."
 ---
 
 ## Automating Kubernetes Policy Enforcement with OPA Gatekeeper and GitOps

--- a/blog-src/src/content/posts/2026-05-19-custom-tcp-congestion-control-for-low-latency-linux-networks.md
+++ b/blog-src/src/content/posts/2026-05-19-custom-tcp-congestion-control-for-low-latency-linux-networks.md
@@ -3,7 +3,7 @@ title: "Custom TCP Congestion Control for Low-Latency Linux Networks"
 date: 2026-05-19
 category: "thought-leadership"
 tags: []
-excerpt: "Network latency is a critical factor in the performance of modern applications, from high-frequency trading platforms to real-time communication syste..."
+excerpt: "Network latency is a critical factor in the performance of modern applications, from high-frequency trading platforms to real-time communication..."
 ---
 
 # Optimizing Network Latency with Custom TCP Congestion Control Algorithms in Linux

--- a/blog-src/src/content/posts/2026-05-28-automating-dns-service-discovery-and-load-balancing-with-coredns-and-ebpf.md
+++ b/blog-src/src/content/posts/2026-05-28-automating-dns-service-discovery-and-load-balancing-with-coredns-and-ebpf.md
@@ -3,7 +3,7 @@ title: "Automating DNS Service Discovery and Load Balancing With CoreDNS and eBP
 date: 2026-05-28
 category: "thought-leadership"
 tags: []
-excerpt: "In the dynamic world of modern infrastructure, services are constantly being spun up, scaled, and terminated. Manually updating DNS records or load ba..."
+excerpt: "In the dynamic world of modern infrastructure, services are constantly being spun up, scaled, and terminated. Manually updating DNS records or load..."
 ---
 
 # Automating DNS Service Discovery and Load Balancing With CoreDNS and eBPF

--- a/blog-src/src/content/posts/2026-05-29-achieving-nanosecond-latency-a-deep-dive-into-kernel-bypass-networking.md
+++ b/blog-src/src/content/posts/2026-05-29-achieving-nanosecond-latency-a-deep-dive-into-kernel-bypass-networking.md
@@ -3,7 +3,7 @@ title: "Achieving Nanosecond Latency: A Deep Dive into Kernel-Bypass Networking"
 date: 2026-05-29
 category: "thought-leadership"
 tags: []
-excerpt: "In the world of high-frequency trading, real-time analytics, and high-performance computing, every microsecond, or even nanosecond, counts. Traditiona..."
+excerpt: "In the world of high-frequency trading, real-time analytics, and high-performance computing, every microsecond, or even nanosecond, counts..."
 ---
 
 # Achieving Nanosecond Latency: A Deep Dive into Kernel-Bypass Networking

--- a/scripts/lib/blog-post.js
+++ b/scripts/lib/blog-post.js
@@ -348,12 +348,17 @@ export function stripTitleDirective(content) {
 }
 
 export function makeExcerpt(content) {
-  return stripTitleDirective(content)
+  const text = stripTitleDirective(content)
     .replace(/^#.+\n+/, '')
     .replace(/[#*`\[\]]/g, '')
-    .trim()
-    .slice(0, 150)
-    .trim() + '...';
+    .trim();
+  let sliced = text.slice(0, 150);
+  // If the 150-char cut lands mid-word, back up to the last word boundary so
+  // the ellipsis never splits a word (which also trips the CI spell check).
+  if (/\S/.test(text[150] ?? '') && /\s\S+$/.test(sliced)) {
+    sliced = sliced.replace(/\s+\S+$/, '');
+  }
+  return sliced.trim() + '...';
 }
 
 // Optionally groups a post into a multi-part series. When `series` is supplied

--- a/tests/lib/blog-post.test.js
+++ b/tests/lib/blog-post.test.js
@@ -115,6 +115,11 @@ describe('makeExcerpt', () => {
     const body = 'TITLE: Foo Bar Baz Qux\n\n# Foo Bar Baz Qux\n\nReal body content here.';
     expect(makeExcerpt(body)).toBe('Real body content here....');
   });
+  it('never cuts mid-word at the 150-char limit', () => {
+    const body = '# Title\n\n' + 'supercalifragilistic '.repeat(20);
+    const ex = makeExcerpt(body);
+    expect(ex.endsWith('supercalifragilistic...')).toBe(true);
+  });
   it('strips common markdown punctuation', () => {
     const body = '# Title\n\n**Bold** and `code` and [link](http://x) text';
     expect(makeExcerpt(body)).not.toContain('**');


### PR DESCRIPTION
New workflows, all SHA-pinned with least-privilege permissions:
- ci.yml: Worker/lib tests, Astro typecheck, full production build on
  PRs and master pushes
- dependabot-auto-merge.yml: flag grouped minor/patch Dependabot PRs
  for auto-merge (majors stay human-reviewed)
- gitleaks.yml: enforced secret scanning (CI counterpart to the
  optional pre-commit hook)
- codeql.yml: JavaScript/TypeScript static analysis on PRs, pushes,
  and a weekly schedule
- link-check.yml: weekly lychee sweep of blog content that files or
  updates a tracking issue with the report
- lint-workflows.yml: actionlint (checksum-verified binary) + zizmor
  on workflow YAML changes
- typos.yml: crate-ci/typos spell check, exceptions in _typos.toml

Supporting fixes so the new checks land green:
- makeExcerpt now truncates at a word boundary instead of slicing at
  exactly 150 chars, which had been splitting words mid-token in
  generated excerpts (test added)
- trim the nine existing post excerpts affected by that bug and fix a
  'Playgorund' -> 'Playground' typo
- .github/zizmor.yml ignores artipacked for the two workflows that
  legitimately push with git credentials
- README documents the new workflows and the auto-merge prerequisites

https://claude.ai/code/session_01EhqFygE6Hy8bWnbSYQpNB9