### PR TITLE
Install blog-src deps in CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,19 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            blog-src/package-lock.json
 
       - name: Install dependencies
         run: npm ci
+
+      # The lib tests import Astro-side modules (blog-src/src/utils), which
+      # need blog-src's node_modules for both their imports (pdfkit, wawoff2)
+      # and the tsconfig extends chain (astro/tsconfigs/strict).
+      - name: Install site dependencies
+        run: npm ci
+        working-directory: blog-src
 
       # Worker integration tests (real Workers runtime + Miniflare D1) and
       # shared-lib unit tests.


### PR DESCRIPTION
The lib test suite imports blog-src/src/utils/resumePdf.ts, whose
transform requires blog-src/tsconfig.json's extends target
(astro/tsconfigs/strict) to be resolvable, and whose imports (pdfkit,
wawoff2) live in blog-src/node_modules. The test job only ran npm ci at
the repo root, so the suite failed with TSCONFIG_ERROR.

https://claude.ai/code/session_01AZcetuCsxhP2gTZwzsavmB