### PR TITLE
Turn the cache-purge workflow into a deploy-status badge

### DIFF
--- a/.github/workflows/purge-cloudflare-cache.yml
+++ b/.github/workflows/purge-cloudflare-cache.yml
@@ -56,6 +56,15 @@ jobs:
     needs: purge
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      # Probe the Worker's workers.dev URL rather than the custom domain:
+      # the zone's bot protection challenges automated requests from CI
+      # runners with a 403 before they ever reach the Worker, while
+      # workers.dev sits outside the zone and hits the Worker directly.
+      # If the account subdomain differs, set the DEPLOY_CHECK_HOST
+      # repository *variable* (Settings → Secrets and variables → Actions
+      # → Variables) — no secrets required.
+      DEPLOY_CHECK_HOST: ${{ vars.DEPLOY_CHECK_HOST || 'resumesite.laplantewebdevelopment.workers.dev' }}
     steps:
       - name: Check live site
         run: |
@@ -64,8 +73,7 @@ jobs:
             local desc=$1 url=$2 expected=$3
             local status attempt
             for attempt in 1 2 3; do
-              # Identifiable UA so the request is distinguishable in logs and
-              # can be exempted if Cloudflare bot protection challenges it.
+              # Identifiable UA so the probe is distinguishable in logs.
               status=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 \
                 -A 'resumesite-deploy-check (+https://github.com/mlaplante/resumesite)' \
                 "$url" || echo 000)
@@ -80,8 +88,8 @@ jobs:
             return 1
           }
           # Static assets served by the Worker's ASSETS binding.
-          check "static site" "https://michaellaplante.com/" 200
+          check "static site" "https://${DEPLOY_CHECK_HOST}/" 200
           # GET /api/contact returns 405 from the Worker router itself, so this
-          # proves the Worker is deployed and routing — a Cloudflare error page
-          # or a missing Worker would return 5xx/404 instead.
-          check "worker API route" "https://michaellaplante.com/api/contact" 405
+          # proves the Worker is deployed and routing — a missing Worker would
+          # return 404/5xx instead.
+          check "worker API route" "https://${DEPLOY_CHECK_HOST}/api/contact" 405

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The site deploys to **Cloudflare** as a Worker plus static assets:
 1. Build emits the static site into `dist/` (configured via `astro.config.mjs`)
 2. `wrangler deploy` uploads the Worker (`worker/index.ts`) and the assets directory together
 3. The Worker handles `/api/contact`; everything else is served from the bound `ASSETS` fetcher
-4. The `purge-cloudflare-cache.yml` workflow fires on pushes to `master` and verifies the live site and Worker route respond — its README badge doubles as a deploy-status badge. If the `CLOUDFLARE_ZONE_ID` / `CLOUDFLARE_API_TOKEN` secrets are configured it also purges the edge cache first; otherwise the purge is skipped and cached content simply expires on its normal TTL
+4. The `purge-cloudflare-cache.yml` workflow fires on pushes to `master` and verifies the deployed Worker responds — its README badge doubles as a deploy-status badge. It probes the `workers.dev` URL (not the custom domain, whose bot protection 403s CI runners); if your account subdomain differs from the default, set the `DEPLOY_CHECK_HOST` repository variable. If the `CLOUDFLARE_ZONE_ID` / `CLOUDFLARE_API_TOKEN` secrets are configured it also purges the edge cache first; otherwise the purge is skipped and cached content simply expires on its normal TTL
 
 ### GitHub Actions Workflows
 


### PR DESCRIPTION
## Summary

Makes the `purge-cloudflare-cache.yml` workflow act as a Netlify-style deploy-status badge for our Worker deploys, working with or without the Cloudflare API secrets.

- **Renamed the workflow to "Deploy Status"** so the README badge reads `Deploy Status: passing/failing`. The filename is unchanged, so the existing badge URL keeps working.
- **Added a `verify` job** that runs after the purge and probes the deployed Worker (3 retries, 10s backoff):
  - `GET /` must return **200** — static assets are serving
  - `GET /api/contact` must return **405** — that response comes from the Worker router itself (`worker/index.ts`), proving the Worker is deployed and routing; a missing Worker would return 404/5xx
- **Probes `resumesite.laplantewebdevelopment.workers.dev`** instead of the custom domain: the zone's bot protection 403s automated requests from CI runners before they reach the Worker (confirmed in a live run). The host can be overridden with the `DEPLOY_CHECK_HOST` repository variable — no secrets required.
- **Cache purge is now best-effort**: when `CLOUDFLARE_ZONE_ID` / `CLOUDFLARE_API_TOKEN` aren't configured, the purge step logs a notice and skips instead of failing, so the badge reflects deploy status alone. Adding the secrets later re-enables purging with no workflow changes.

## Testing

- `actionlint` 1.7.12 (with shellcheck 0.10.0) and `zizmor` 1.25.2 — the same tools `lint-workflows.yml` runs — pass locally.
- Live-probe semantics verified against the Worker router code; the custom-domain 403 behavior was confirmed by an actual workflow run.

## Notes

- The badge attests the **Worker deploy** is healthy, not the custom domain itself — the trade-off for not fighting Cloudflare bot protection.
- The badge refreshes on pushes to master and manual dispatch; a follow-up could add a `schedule:` trigger to track liveness continuously.

https://claude.ai/code/session_011UxA3WQ6fdX6Xh4Pa7T8qT

---
_Generated by [Claude Code](https://claude.ai/code/session_011UxA3WQ6fdX6Xh4Pa7T8qT)_