### PR TITLE
Fix license inconsistency, add SECURITY.md, add site-level tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,12 @@ jobs:
       # and runs the PurgeCSS pass.
       - name: Build site
         run: npm run build
+
+      # Root tooling (vitest) for the build-output smoke tests below.
+      - name: Install root dependencies
+        run: npm ci
+
+      # Smoke-test the freshly built dist/: required routes/endpoints exist,
+      # OG cards and the PDF résumé rendered, search index is populated.
+      - name: Smoke-test build output
+        run: npx vitest run --project site

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2006-2026 LaPlante Web Development. All rights reserved.
+
+This repository and its contents — including but not limited to the source
+code, written content, blog posts, résumé data, images, and design — are the
+proprietary work of Michael LaPlante / LaPlante Web Development.
+
+No license, express or implied, is granted to copy, modify, distribute,
+republish, or create derivative works from any part of this repository,
+in whole or in part, without prior written permission from the copyright
+holder.
+
+You may view the source for reference and educational purposes. Reuse of
+the written content (blog posts, résumé, and biographical material) is not
+permitted without attribution and prior written consent.
+
+THE SOFTWARE AND CONTENT ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES,
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE,
+ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR CONTENT OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE OR CONTENT.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+Thanks for helping keep [michaellaplante.com](https://michaellaplante.com) and
+its users safe.
+
+## Reporting a Vulnerability
+
+If you believe you've found a security issue in this repository or the live
+site, please report it privately rather than opening a public issue.
+
+Preferred channels, in order:
+
+1. **GitHub** — open a [private security advisory](https://github.com/mlaplante/resumesite/security/advisories/new)
+   (Security → Advisories → "Report a vulnerability").
+2. **Contact form** — <https://michaellaplante.com/#contact>
+
+The site also publishes a machine-readable policy per
+[RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) at
+<https://michaellaplante.com/.well-known/security.txt>.
+
+Please include enough detail to reproduce the issue (affected URL or file,
+steps, and impact). A proof of concept is appreciated but not required.
+
+## Scope
+
+In scope:
+
+- The Cloudflare Worker and `/api/contact` backend (`worker/`)
+- The Astro site build and its content/output (`blog-src/`)
+- The CI/CD workflows and AI draft-generation scripts (`.github/`, `scripts/`)
+
+Out of scope:
+
+- Reports from automated scanners with no demonstrated impact
+- Missing security headers already covered by `blog-src/public/_headers`
+- Denial-of-service / volumetric testing against the live site
+- Social engineering, physical attacks, or third-party services
+  (Cloudflare, ForwardEmail, Buttondown, Cal.com) — report those to the
+  respective vendor
+
+## Disclosure
+
+This is a personal site, so there's no formal SLA, but I aim to acknowledge
+reports within a few days. Please give a reasonable window to remediate before
+any public disclosure.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/mlaplante/resumesite"
   },
   "author": "Michael LaPlante",
-  "license": "MIT",
+  "license": "UNLICENSED",
   "keywords": [
     "portfolio",
     "resume",

--- a/tests/site/build-output.test.ts
+++ b/tests/site/build-output.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Smoke-tests the actual production build. Run after `npm run build` (CI does
+// this in the "Astro typecheck + build" job); when `dist/` is absent — e.g. a
+// plain local `npm test` — the whole suite is skipped so it never blocks.
+const DIST = join(dirname(fileURLToPath(import.meta.url)), '../../dist');
+const hasDist = existsSync(DIST);
+
+describe.skipIf(!hasDist)('production build output', () => {
+  // Key routes / endpoints that must always ship. A broken page or renamed
+  // route shows up here instead of as a silent 404 in production.
+  const required = [
+    'index.html',
+    'resume/index.html',
+    'resume.pdf',
+    'services/index.html',
+    'uses/index.html',
+    'privacy/index.html',
+    '404.html',
+    'blog/index.html',
+    'blog/about/index.html',
+    'blog/rss.xml',
+    'blog/search.json',
+    'feed.json',
+    'sitemap-index.xml',
+    'llms-full.txt',
+    'robots.txt',
+    '_headers',
+  ];
+
+  it.each(required)('emits %s', (rel) => {
+    expect(existsSync(join(DIST, rel)), `dist/${rel} is missing`).toBe(true);
+  });
+
+  it('renders a non-trivial home page', () => {
+    const html = readFileSync(join(DIST, 'index.html'), 'utf8');
+    expect(html).toContain('<title');
+    expect(html.length).toBeGreaterThan(1000);
+  });
+
+  it('generates a per-post Open Graph card for every post', () => {
+    const ogDir = join(DIST, 'og');
+    expect(existsSync(ogDir), 'dist/og is missing').toBe(true);
+    const pngs = readdirSync(ogDir).filter((f) => f.endsWith('.png'));
+    expect(pngs.length).toBeGreaterThan(0);
+  });
+
+  it('produces a real (non-empty) PDF résumé', () => {
+    const pdf = readFileSync(join(DIST, 'resume.pdf'));
+    expect(pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+    expect(statSync(join(DIST, 'resume.pdf')).size).toBeGreaterThan(20_000);
+  });
+
+  it('builds a populated client-side search index', () => {
+    const index = JSON.parse(
+      readFileSync(join(DIST, 'blog/search.json'), 'utf8'),
+    );
+    expect(Array.isArray(index)).toBe(true);
+    expect(index.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/site/content.test.ts
+++ b/tests/site/content.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Mirrors the build-time content-collection schema (blog-src/src/content.config.ts)
+// so authoring mistakes surface in a fast `npm test` run instead of only at the
+// full `astro build`. The glob loader skips files whose names start with `_` or
+// an uppercase letter (drafts / CLAUDE.md), so apply the same filter here.
+const POSTS_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../blog-src/src/content/posts',
+);
+
+function postFiles(): string[] {
+  return readdirSync(POSTS_DIR).filter(
+    (f) => f.endsWith('.md') && /^[^_A-Z]/.test(f),
+  );
+}
+
+// Extract a single scalar frontmatter value (handles optional surrounding
+// quotes). Returns null when the key is absent or commented out.
+function frontmatter(raw: string): Record<string, string> {
+  const match = raw.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const fields: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    if (/^\s*#/.test(line)) continue; // skip commented-out hints
+    const kv = line.match(/^([a-zA-Z0-9_]+):\s*(.*)$/);
+    if (!kv) continue;
+    let value = kv[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    fields[kv[1]] = value;
+  }
+  return fields;
+}
+
+const files = postFiles();
+
+describe('blog content frontmatter', () => {
+  it('has at least one published post', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)('%s has valid frontmatter', (file) => {
+    const raw = readFileSync(join(POSTS_DIR, file), 'utf8');
+    const fm = frontmatter(raw);
+
+    // Required fields (schema: title, date, category, excerpt).
+    for (const key of ['title', 'date', 'category', 'excerpt'] as const) {
+      expect(fm[key], `${file}: missing "${key}"`).toBeTruthy();
+    }
+
+    // Lengths match the Zod schema bounds.
+    expect(fm.title.length, `${file}: title too long`).toBeLessThanOrEqual(200);
+    expect(fm.excerpt.length, `${file}: excerpt too long`).toBeLessThanOrEqual(
+      300,
+    );
+
+    // Category is a lowercase-hyphenated slug.
+    expect(fm.category, `${file}: category not slug-cased`).toMatch(
+      /^[a-z0-9-]+$/,
+    );
+
+    // Date parses to a real calendar date.
+    expect(
+      Number.isNaN(new Date(fm.date).getTime()),
+      `${file}: unparseable date "${fm.date}"`,
+    ).toBe(false);
+
+    // updated, when present, is not before date.
+    if (fm.updated) {
+      expect(
+        new Date(fm.updated).getTime(),
+        `${file}: updated precedes date`,
+      ).toBeGreaterThanOrEqual(new Date(fm.date).getTime());
+    }
+  });
+
+  it('has unique slugs (filenames)', () => {
+    const slugs = files.map((f) => f.replace(/\.md$/, ''));
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,16 @@ export default defineConfig({
           environment: 'node',
         },
       },
+      {
+        // Site-level checks: content frontmatter validation (always runs) and
+        // production build-output smoke tests (self-skip when dist/ is absent,
+        // so they only assert in the CI build job that runs `npm run build`).
+        test: {
+          name: 'site',
+          include: ['tests/site/**/*.test.ts'],
+          environment: 'node',
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
- License: package.json claimed MIT while the README reserved all rights and
  no LICENSE file existed. Set package.json to UNLICENSED and add a proprietary
  LICENSE matching the README's "all rights reserved" intent.
- Add a root SECURITY.md so GitHub's vulnerability-reporting flow points at the
  existing security.txt / contact channels, with scope and disclosure notes.
- Add a "site" vitest project covering content frontmatter (mirrors the Zod
  schema; runs without a build) and production build-output smoke tests
  (required routes/endpoints, OG cards, PDF resume, search index). The
  build-output tests self-skip when dist/ is absent and run in the CI build job
  after `npm run build`.